### PR TITLE
Validating consecutive timestamps in seconds instead of milliseconds

### DIFF
--- a/deploy/contracts/Advertisement.sol
+++ b/deploy/contracts/Advertisement.sol
@@ -169,7 +169,8 @@ contract Advertisement {
 		require (timestampList.length == nonces.length);
 		//Expect ordered array arranged in ascending order
 		for(uint i = 0; i < timestampList.length-1; i++){
-			require((timestampList[i+1]-timestampList[i]) == 10000);
+		        uint timestamp_diff = (timestampList[i+1]-timestampList[i]);
+			require((timestamp_diff / 1000) == 10);
 		}
 
 		require(!userAttributions[msg.sender][bidId]);


### PR DESCRIPTION
Timestamps should be accurate to the second but not to the millisecond, i.e. most cases the difference between consecutive timestamps will be something like **10009** or **10012**, and not exactly **10000**.