### PR TITLE
Feature/validate nonces

### DIFF
--- a/deploy/contracts/Advertisement.sol
+++ b/deploy/contracts/Advertisement.sol
@@ -172,6 +172,8 @@ contract Advertisement {
 			require((timestampList[i+1]-timestampList[i]) == 10000);
 		}
 
+		verifyNonces(packageName,timestampList,nonces);
+
 		require(!userAttributions[msg.sender][bidId]);
 		//atribute
 		userAttributions[msg.sender][bidId] = true;
@@ -303,10 +305,45 @@ contract Advertisement {
 		campaign.budget -= campaign.price;
 	}
 
+	function verifyNonces (string packageName,uint[] timestampList, uint[] nonces) internal {
+		
+		for(uint i = 0; i < nonces.length; i++){
+			bytes32[2] memory byteList;
+
+			byteList[0] = stringToBytes32(packageName);
+
+			byteList[1] = uintToBytes(timestampList[i]);
+			byteList[0] = sha256(byteList);
+			byteList[1] = uintToBytes(nonces[i]);
+			
+			bytes32 result = sha256(byteList);
+			bytes2[1] memory leadingBytes = [bytes2(0)];
+			bytes2 comp = 0x0000;
+			
+			assembly{
+				mstore(leadingBytes,result)
+			}
+
+			require(comp == leadingBytes[0]);			
+		}
+	}
+	
+
 	function division(uint numerator, uint denominator) public constant returns (uint) {
                 uint _quotient = numerator / denominator;
         return _quotient;
     }
+
+    function stringToBytes32(string memory source) returns (bytes32 result) {
+	    bytes memory tempEmptyStringTest = bytes(source);
+	    if (tempEmptyStringTest.length == 0) {
+	        return 0x0;
+	    }
+
+	    assembly {
+	        result := mload(add(source, 32))
+	    }
+	}
 
 	function uintToBytes (uint256 i) constant returns(bytes32 b)  {
 		b = bytes32(i);

--- a/deploy/contracts/Advertisement.sol
+++ b/deploy/contracts/Advertisement.sol
@@ -62,7 +62,6 @@ contract Advertisement {
 	event PoARegistered(bytes32 bidId, string packageName,
 						uint64[] timestampList,uint64[] nonceList);	
 
-	event FinalHash(bytes32 list);
     /**
     * Constructor function
     *
@@ -166,12 +165,12 @@ contract Advertisement {
 						uint64[] timestampList, uint64[] nonces,
 						address appstore, address oem) external {
 
-	/*	require (timestampList.length == nonces.length);
+		require (timestampList.length == nonces.length);
 		//Expect ordered array arranged in ascending order
 		for(uint i = 0; i < timestampList.length-1; i++){
 			require((timestampList[i+1]-timestampList[i]) == 10000);
 		}
-	*/
+		
 		verifyNonces(bytes(packageName),timestampList,nonces);
 
 		require(!userAttributions[msg.sender][bidId]);
@@ -305,7 +304,7 @@ contract Advertisement {
 		campaign.budget -= campaign.price;
 	}
 
-	function verifyNonces (bytes packageName,uint64[] timestampList, uint64[] nonces) public view {
+	function verifyNonces (bytes packageName,uint64[] timestampList, uint64[] nonces) internal {
 		
 		for(uint i = 0; i < nonces.length; i++){
 			bytes8 timestamp = bytes8(timestampList[i]);
@@ -334,9 +333,6 @@ contract Advertisement {
 			
 			result = sha256(noncePlusHash);
 			
-			FinalHash(result);
-			
-/*
 			bytes2[1] memory leadingBytes = [bytes2(0)];
 			bytes2 comp = 0x0000;
 			
@@ -345,7 +341,7 @@ contract Advertisement {
 			}
 		
 			require(comp == leadingBytes[0]);			
-*/		
+		
 		}
 	}
 	

--- a/deploy/contracts/Advertisement.sol
+++ b/deploy/contracts/Advertisement.sol
@@ -61,7 +61,8 @@ contract Advertisement {
 
 	event PoARegistered(bytes32 bidId, string packageName,
 						uint64[] timestampList,uint64[] nonceList);	
-	event TestList(uint pl,uint tl,bytes list);
+
+	event FinalHash(bytes32 list);
     /**
     * Constructor function
     *
@@ -308,6 +309,7 @@ contract Advertisement {
 		
 		for(uint i = 0; i < nonces.length; i++){
 			bytes8 timestamp = bytes8(timestampList[i]);
+			bytes8 nonce = bytes8(nonces[i]);
 			bytes memory byteList = new bytes(packageName.length + timestamp.length);
 
 			for(uint j = 0; j < packageName.length;j++){
@@ -318,10 +320,23 @@ contract Advertisement {
 				byteList[j + packageName.length] = timestamp[j];
 			}
 
-			TestList(packageName.length,timestamp.length,byteList);
-		/*	byteList[0] = sha256(byteList);
-			byteList[1] = uintToBytes(nonces[i]);
 			bytes32 result = sha256(byteList);
+			
+			bytes memory noncePlusHash = new bytes(result.length + nonce.length);
+
+			for(j = 0; j < nonce.length; j++){
+				noncePlusHash[j] = nonce[j];
+			} 
+
+			for(j = 0; j < result.length; j++){
+				noncePlusHash[j + nonce.length] = result[j];
+			}
+			
+			result = sha256(noncePlusHash);
+			
+			FinalHash(result);
+			
+/*
 			bytes2[1] memory leadingBytes = [bytes2(0)];
 			bytes2 comp = 0x0000;
 			
@@ -330,7 +345,7 @@ contract Advertisement {
 			}
 		
 			require(comp == leadingBytes[0]);			
-		*/
+*/		
 		}
 	}
 	

--- a/deploy/contracts/Advertisement.sol
+++ b/deploy/contracts/Advertisement.sol
@@ -60,8 +60,8 @@ contract Advertisement {
 							uint startDate, uint endDate);
 
 	event PoARegistered(bytes32 bidId, string packageName,
-						uint[] timestampList,uint[] nonceList);	
-
+						uint64[] timestampList,uint64[] nonceList);	
+	event TestList(uint pl,uint tl,bytes list);
     /**
     * Constructor function
     *
@@ -140,7 +140,6 @@ contract Advertisement {
 				country[countryLength]=countriesInBytes[i];
 				countryLength++;
 			}
-
 		}
 
 	}
@@ -163,16 +162,16 @@ contract Advertisement {
 	}
 
 	function registerPoA (string packageName, bytes32 bidId,
-						uint[] timestampList, uint[] nonces,
+						uint64[] timestampList, uint64[] nonces,
 						address appstore, address oem) external {
 
-		require (timestampList.length == nonces.length);
+	/*	require (timestampList.length == nonces.length);
 		//Expect ordered array arranged in ascending order
 		for(uint i = 0; i < timestampList.length-1; i++){
 			require((timestampList[i+1]-timestampList[i]) == 10000);
 		}
-
-		verifyNonces(packageName,timestampList,nonces);
+	*/
+		verifyNonces(bytes(packageName),timestampList,nonces);
 
 		require(!userAttributions[msg.sender][bidId]);
 		//atribute
@@ -305,17 +304,23 @@ contract Advertisement {
 		campaign.budget -= campaign.price;
 	}
 
-	function verifyNonces (string packageName,uint[] timestampList, uint[] nonces) internal {
+	function verifyNonces (bytes packageName,uint64[] timestampList, uint64[] nonces) public view {
 		
 		for(uint i = 0; i < nonces.length; i++){
-			bytes32[2] memory byteList;
+			bytes8 timestamp = bytes8(timestampList[i]);
+			bytes memory byteList = new bytes(packageName.length + timestamp.length);
 
-			byteList[0] = stringToBytes32(packageName);
+			for(uint j = 0; j < packageName.length;j++){
+				byteList[j] = packageName[j];
+			}
 
-			byteList[1] = uintToBytes(timestampList[i]);
-			byteList[0] = sha256(byteList);
+			for(j = 0; j < timestamp.length; j++ ){
+				byteList[j + packageName.length] = timestamp[j];
+			}
+
+			TestList(packageName.length,timestamp.length,byteList);
+		/*	byteList[0] = sha256(byteList);
 			byteList[1] = uintToBytes(nonces[i]);
-			
 			bytes32 result = sha256(byteList);
 			bytes2[1] memory leadingBytes = [bytes2(0)];
 			bytes2 comp = 0x0000;
@@ -323,8 +328,9 @@ contract Advertisement {
 			assembly{
 				mstore(leadingBytes,result)
 			}
-
+		
 			require(comp == leadingBytes[0]);			
+		*/
 		}
 	}
 	
@@ -333,17 +339,6 @@ contract Advertisement {
                 uint _quotient = numerator / denominator;
         return _quotient;
     }
-
-    function stringToBytes32(string memory source) returns (bytes32 result) {
-	    bytes memory tempEmptyStringTest = bytes(source);
-	    if (tempEmptyStringTest.length == 0) {
-	        return 0x0;
-	    }
-
-	    assembly {
-	        result := mload(add(source, 32))
-	    }
-	}
 
 	function uintToBytes (uint256 i) constant returns(bytes32 b)  {
 		b = bytes32(i);

--- a/deploy/test/advertisement.js
+++ b/deploy/test/advertisement.js
@@ -24,6 +24,58 @@ async function getBalance(account) {
 
 contract('Advertisement', function(accounts) {
   beforeEach(async () => {
+	
+		nounceWrongTs = [ 70356,
+						45021,
+						32669,
+						37785,
+						15906,
+						10179,
+						17014,
+						167317,
+						63419,
+						381,
+						31182,
+						52274];
+
+		nonceList = [ 75824,
+					111779,
+					188882,
+					15136,
+					5936,
+					41188,
+					55418,
+					162348,
+					29001,
+					99111,
+					119649,
+					30337];
+
+		timestamp = [ 1524042553578,
+					  1524042563843,
+					  1524042574305,
+					  1524042584823,
+					  1524042595355,
+					  1524042605651,
+					  1524042615837,
+					  1524042626245,
+					  1524042636491,
+					  1524042646740,
+					  1524042657099,
+					  1524042667471 ];
+
+		wrongTimestamp = [ 1524042553761,
+						  1524042554294,
+						  1524042554557,
+						  1524042555200,
+						  1524042555437,
+						  1524042555714,
+						  1524042556061,
+						  1524042556318,
+						  1524042556654,
+						  1524042557044,
+						  1524042557465,
+						  1524042557509 ];
 
 		appcInstance = await AppCoins.new();
 		
@@ -59,15 +111,20 @@ contract('Advertisement', function(accounts) {
 		wrongTimestampPoA.nonce = new Array();
 
 		for(var i = 0; i < 12; i++){
-			var timeNow = new Date().getTime();
-			var time = timeNow+10000*i;
-			var wrongTime = new Date().getTime()+i;
+			//var timeNow = new Date().getTime();
+			var time = timestamp[i];
+			//var time = 158326;
+
+			var wrongTime = wrongTimestamp[i];
+			//var correctNonce = Math.floor(Math.random()*520*i);
+			var correctNonce = nonceList[i];
+			var wrongTimeNonce = nounceWrongTs[i];
 			examplePoA.timestamp.push(time);
-			examplePoA.nonce.push(Math.floor(Math.random()*500*i));
+			examplePoA.nonce.push(correctNonce);
 			example2PoA.timestamp.push(time);
-			example2PoA.nonce.push(Math.floor(Math.random()*520*i));
+			example2PoA.nonce.push(correctNonce);
 			wrongTimestampPoA.timestamp.push(wrongTime);
-			wrongTimestampPoA.nonce.push(Math.floor(Math.random()*520*i));
+			wrongTimestampPoA.nonce.push(wrongTimeNonce);
 		}
 	});
 

--- a/deploy/test/advertisement.js
+++ b/deploy/test/advertisement.js
@@ -24,7 +24,7 @@ async function getBalance(account) {
 
 contract('Advertisement', function(accounts) {
   beforeEach(async () => {
-		
+
 		appcInstance = await AppCoins.new();
 		
 		addInstance = await	Advertisement.new(appcInstance.address);
@@ -60,11 +60,13 @@ contract('Advertisement', function(accounts) {
 
 		for(var i = 0; i < 12; i++){
 			var timeNow = new Date().getTime();
-			examplePoA.timestamp.push(timeNow+10000*i);
+			var time = timeNow+10000*i;
+			var wrongTime = new Date().getTime()+i;
+			examplePoA.timestamp.push(time);
 			examplePoA.nonce.push(Math.floor(Math.random()*500*i));
-			example2PoA.timestamp.push(new Date().getTime()+10000*i);
+			example2PoA.timestamp.push(time);
 			example2PoA.nonce.push(Math.floor(Math.random()*520*i));
-			wrongTimestampPoA.timestamp.push(new Date().getTime()+i);
+			wrongTimestampPoA.timestamp.push(wrongTime);
 			wrongTimestampPoA.nonce.push(Math.floor(Math.random()*520*i));
 		}
 	});

--- a/deploy/test/advertisement.js
+++ b/deploy/test/advertisement.js
@@ -25,7 +25,7 @@ async function getBalance(account) {
 contract('Advertisement', function(accounts) {
   beforeEach(async () => {
 	
-		nounceWrongTs = [ 70356,
+		nonceWrongTs = [ 70356,
 						45021,
 						32669,
 						37785,
@@ -110,6 +110,13 @@ contract('Advertisement', function(accounts) {
 		wrongTimestampPoA.timestamp = new Array();
 		wrongTimestampPoA.nonce = new Array();
 
+		wrongNoncePoA = new Object();
+		wrongNoncePoA.packageName = examplePoA.packageName;
+		wrongNoncePoA.bid = web3.utils.toHex("0x0000000000000000000000000000000000000000000000000000000000000000");
+		wrongNoncePoA.timestamp = new Array();
+		// any nounce list except the correct one will work here 
+		wrongNoncePoA.nonce = new Array();
+
 		for(var i = 0; i < 12; i++){
 			//var timeNow = new Date().getTime();
 			var time = timestamp[i];
@@ -118,13 +125,15 @@ contract('Advertisement', function(accounts) {
 			var wrongTime = wrongTimestamp[i];
 			//var correctNonce = Math.floor(Math.random()*520*i);
 			var correctNonce = nonceList[i];
-			var wrongTimeNonce = nounceWrongTs[i];
+			var wrongTimeNonce = nonceWrongTs[i];
 			examplePoA.timestamp.push(time);
 			examplePoA.nonce.push(correctNonce);
 			example2PoA.timestamp.push(time);
 			example2PoA.nonce.push(correctNonce);
 			wrongTimestampPoA.timestamp.push(wrongTime);
 			wrongTimestampPoA.nonce.push(wrongTimeNonce);
+			wrongNoncePoA.timestamp.push(time);
+			wrongNoncePoA.nonce.push(nonceWrongTs[i]);
 		}
 	});
 
@@ -237,6 +246,15 @@ contract('Advertisement', function(accounts) {
 	it('should revert registerPoA if timestamps are not spaced exactly 10 secounds from each other', async function () {
 		var reverted = false;
 		await addInstance.registerPoA(wrongTimestampPoA.packageName,wrongTimestampPoA.bid,wrongTimestampPoA.timestamp,wrongTimestampPoA.nonce,accounts[1],accounts[2]).catch(
+			(err) => {
+				reverted = expectRevert.test(err.message);
+			});
+		expect(reverted).to.be.equal(true,"Revert expected");
+	})
+
+	it('should revert registerPoA if nounces do not generate correct leading zeros', async function () {
+		var reverted = false;
+		await addInstance.registerPoA(wrongNoncePoA.packageName,wrongNoncePoA.bid,wrongNoncePoA.timestamp,wrongNoncePoA.nonce,accounts[1],accounts[2]).catch(
 			(err) => {
 				reverted = expectRevert.test(err.message);
 			});


### PR DESCRIPTION
Does not have wallet packageName nor proofId.
Added nonce validation to expect nonces generated with 4 leading zeros based on:
``` 
proof = {
            "campaignId": "1234567890",
            "packageName": "com.asf.appcoins.toolbox",
            "proofComponentList": [{
                "nonce": 62866,
                "timeStamp": 1523267455576
            }, {
                "nonce": 75133,
                "timeStamp": 1523267454944
            }, {
                "nonce": 71261,
                "timeStamp": 1523267455838
            }, {
                "nonce": 26981,
                "timeStamp": 1523267457399
            }, {
                "nonce": 10437,
                "timeStamp": 1523267459594
            }, {
                "nonce": 58625,
                "timeStamp": 1523267456301
            }, {
                "nonce": 23146,
                "timeStamp": 1523267458497
            }, {
                "nonce": 81928,
                "timeStamp": 1523267457915
            }, {
                "nonce": 159119,
                "timeStamp": 1523267455352
            }, {
                "nonce": 12152,
                "timeStamp": 1523267460112
            }, {
                "nonce": 12713,
                "timeStamp": 1523267460626
            }, {
                "nonce": 8387,
                "timeStamp": 1523267462186
            }]
        }

N = 4
for each component in proof["proofComponentList"]:
* c =proof["packageName"]+component["timeStamp"]
* hash_c = sha256(c)
* str_aux = component["nonce"] + hash_c
* pow = sha256(str_aux)
* check if pow has N leading zeros```