### PR TITLE
Feature/refactor country storage

### DIFF
--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -79,7 +79,7 @@ contract Advertisement {
         newCampaign.startDate = startDate;
         newCampaign.endDate = endDate;
 
-        newCampaign.filters.countries = 
+        (newCampaign.filters.countries[0],newCampaign.filters.countries[1],newCampaign.filters.countries[2]) = 
             CampaignLibrary.convertCountryIndexToBytes(countries);
 
         //Transfers the budget to contract address

--- a/contracts/AdvertisementStorage.sol
+++ b/contracts/AdvertisementStorage.sol
@@ -30,7 +30,7 @@ contract AdvertisementStorage {
             address  owner,
             string ipValidator,
             string packageName,
-            string countries,
+            uint[3] countries,
             uint[] vercodes
     );
 
@@ -45,7 +45,7 @@ contract AdvertisementStorage {
             address  owner,
             string ipValidator,
             string packageName,
-            string countries,
+            uint[3] countries,
             uint[] vercodes
     );
 
@@ -72,7 +72,7 @@ contract AdvertisementStorage {
             address,
             string,
             string,
-            string,
+            uint[3],
             uint[]
         ) {
 
@@ -129,7 +129,7 @@ contract AdvertisementStorage {
     function setCampaignFilters (
         bytes32 bidId,
         string packageName,
-        string countries,
+        uint[3] countries,
         uint[] vercodes
     )
     public
@@ -239,11 +239,11 @@ contract AdvertisementStorage {
     function getCampaignCountriesById(bytes32 bidId)
         public
         view
-        returns (string) {
+        returns (uint[3]) {
         return campaigns[bidId].filters.countries;
     }
 
-    function setCampaignCountriesById(bytes32 bidId, string newCountries)
+    function setCampaignCountriesById(bytes32 bidId, uint[3] newCountries)
         public
         onlyAllowedAddress
         {

--- a/contracts/lib/CampaignLibrary.sol
+++ b/contracts/lib/CampaignLibrary.sol
@@ -3,9 +3,6 @@ pragma solidity ^0.4.19;
 
 library CampaignLibrary {
 
-    event CountryIndexes(uint[3] countries);
-    
-
     struct Filters {
         uint[3] countries;
         string packageName;

--- a/contracts/lib/CampaignLibrary.sol
+++ b/contracts/lib/CampaignLibrary.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.4.19;
 
 library CampaignLibrary {
 
+    event CountryIndexes(uint[3] countries);
+    
+
     struct Filters {
         uint[3] countries;
         string packageName;
@@ -21,21 +24,24 @@ library CampaignLibrary {
         string ipValidator;
     }
 
-    function convertCountryIndexToBytes(uint[] countryIndexes) internal returns (uint[3]){
-        uint[3] memory countries;
+    function convertCountryIndexToBytes(uint[] countries) internal returns (uint,uint,uint){
+        uint countries1 = 0;
+        uint countries2 = 0;
+        uint countries3 = 0;
         for(uint i = 0; i < countries.length; i++){
             uint index = countries[i];
 
             if(index<256){
-                countries[0] = countries[0] | uint(1) << index;
+                countries1 = countries1 | uint(1) << index;
             } else if (index<512) {
-                countries[1] = countries[1] | uint(1) << (index - 256);
+                countries2 = countries2 | uint(1) << (index - 256);
             } else {
-                countries[2] = countries[2] | uint(1) << (index - 512);
+                countries3 = countries3 | uint(1) << (index - 512);
             }
         }
 
-        return countries;
+        return (countries1,countries2,countries3);
     }
+
     
 }

--- a/contracts/lib/CampaignLibrary.sol
+++ b/contracts/lib/CampaignLibrary.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.4.19;
 library CampaignLibrary {
 
     struct Filters {
-        string countries;
+        uint[3] countries;
         string packageName;
         uint[] vercodes;
     }
@@ -20,4 +20,22 @@ library CampaignLibrary {
         Filters filters;
         string ipValidator;
     }
+
+    function convertCountryIndexToBytes(uint[] countryIndexes) internal returns (uint[3]){
+        uint[3] memory countries;
+        for(uint i = 0; i < countries.length; i++){
+            uint index = countries[i];
+
+            if(index<256){
+                countries[0] = countries[0] | uint(1) << index;
+            } else if (index<512) {
+                countries[1] = countries[1] | uint(1) << (index - 256);
+            } else {
+                countries[2] = countries[2] | uint(1) << (index - 512);
+            }
+        }
+
+        return countries;
+    }
+    
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "big-number": "^0.4.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "dotenv": "^5.0.1",

--- a/test/advertisement.js
+++ b/test/advertisement.js
@@ -8,6 +8,7 @@ var expect = chai.expect;
 var chaiAsPromissed = require('chai-as-promised');
 chai.use(chaiAsPromissed);
 
+var BigNumber = require('big-number');
 var appcInstance;
 var addInstance;
 var devShare = 0.85;
@@ -26,26 +27,6 @@ function convertCountryCodeToIndex(countryCode) {
 	var first = new  Buffer(countryCode[0]);
 
 	return buffer.readUInt16BE() - begin.readUInt16BE() - 230*(first.readUInt8()-one.readUInt8());
-}
-
-function buildCountryListFromIndexes(countryList){
-	var countries = [0,0,0];
-
-	for(var i = 0; i< countryList.length; i++){
-		var index = countryList[i];
-		
-		if(index < 256){
-			countries[0] = countries[0] | 1 << index;
-		}else if( index < 512){
-			countries[1] = countries[1] | 1 << (index - 256);
-		}else{
-			countries[2] = countries[2] | 1 << (index - 512);
-		}
-		
-
-	}
-	return countries;
-
 }
 
 contract('Advertisement', function(accounts) {
@@ -183,15 +164,17 @@ contract('Advertisement', function(accounts) {
 		countryList.push(convertCountryCodeToIndex("PT"))
 		countryList.push(convertCountryCodeToIndex("UK"))
 		countryList.push(convertCountryCodeToIndex("FR"))
+		countryList.push(convertCountryCodeToIndex("PA"))
+
 
 		await appcInstance.approve(addInstance.address,campaignBudget);
 		await addInstance.createCampaign("com.instagram.android",countryList,[1,2],campaignPrice,campaignBudget,20,1922838059980);
 		var countries = await addInstance.getCountriesOfCampaign(bid);
-		var expectedCountries = buildCountryListFromIndexes(countryList);
 		
-		expect(JSON.parse(countries[0])).to.be.equal(expectedCountries[0],"First country list storage is incorrect");
-		expect(JSON.parse(countries[1])).to.be.equal(expectedCountries[1],"Secound country list storage is incorrect");
-		expect(JSON.parse(countries[2])).to.be.equal(expectedCountries[2],"Third country list storage is incorrect");
+		expect(JSON.parse(countries[0])).to.be.equal(1.78405961588245e+44,"First country list storage is incorrect");
+		expect(JSON.parse(countries[1])).to.be.equal(1.1418003319719162e+46,"Secound country list storage is incorrect");
+													 
+		expect(JSON.parse(countries[2])).to.be.equal(262144,"Third country list storage is incorrect");
   	});
 
 	it('should cancel a campaign as contract owner', async function () {

--- a/test/advertisement.js
+++ b/test/advertisement.js
@@ -213,7 +213,10 @@ contract('Advertisement', function(accounts) {
 		var userInitBalance = await TestUtils.getBalance(accounts[0]);
 
 		await TestUtils.expectErrorMessageTest('Not enough allowance',async () => {
-			await addInstance.createCampaign.sendTransaction("org.telegram.messenger","UK,FR",[1,2],campaignPrice,campaignBudget,20,1922838059980);
+			var countryList = [];
+			countryList.push(convertCountryCodeToIndex("UK"));
+			countryList.push(convertCountryCodeToIndex("FR"));
+			await addInstance.createCampaign.sendTransaction("org.telegram.messenger",countryList,[1,2],campaignPrice,campaignBudget,20,1922838059980);
 		})
 
 		var newUserBalance = await TestUtils.getBalance(accounts[0]);

--- a/test/advertisement.js
+++ b/test/advertisement.js
@@ -19,6 +19,15 @@ var expectRevert = RegExp('revert');
 var campaignPrice;
 var campaignBudget;
 
+function convertCountryCodeToIndex(countryCode) {
+	var begin = new Buffer("AA");
+	var one = new Buffer("A");
+	var buffer = new  Buffer(countryCode);
+	var first = new  Buffer(countryCode[0]);
+
+	return buffer.readUInt16BE() - begin.readUInt16BE() - 230*(first.readUInt8()-one.readUInt8());
+}
+
 contract('Advertisement', function(accounts) {
   beforeEach('Setting Advertisement test...',async () => {
 
@@ -86,12 +95,18 @@ contract('Advertisement', function(accounts) {
 		campaignPrice = 50000000000000000;
 		campaignBudget = 1000000000000000000;
 
+		countryList = []
+
+		countryList.push(convertCountryCodeToIndex("PT"))
+		countryList.push(convertCountryCodeToIndex("UK"))
+		countryList.push(convertCountryCodeToIndex("FR"))
+
 		await appcInstance.approve(addInstance.address,campaignBudget);
-		await addInstance.createCampaign("com.facebook.orca","PT,UK,FR",[1,2],campaignPrice,campaignBudget,20,1922838059980);
+		await addInstance.createCampaign("com.facebook.orca",countryList,[1,2],campaignPrice,campaignBudget,20,1922838059980);
 
 		await appcInstance.transfer(accounts[1],1000000000000000000);
 		await appcInstance.approve(addInstance.address,campaignBudget,{ from : accounts[1]});
-		await addInstance.createCampaign("com.facebook.orca","PT,UK,FR",[1,2],campaignPrice,campaignBudget,20,1922838059980, { from : accounts[1]});
+		await addInstance.createCampaign("com.facebook.orca",countryList,[1,2],campaignPrice,campaignBudget,20,1922838059980, { from : accounts[1]});
 
 		examplePoA = new Object();
 		examplePoA.packageName = "com.facebook.orca";

--- a/test/advertisementStorage.js
+++ b/test/advertisementStorage.js
@@ -18,7 +18,7 @@ var testCampaign = {
     ipValidator: 1,
     filters: {
         packageName: "com.test.pn",
-        countries: "WL",
+        countries: [409], // PT
         vercodes: [1, 2]
     }
 };


### PR DESCRIPTION
Changed country list storage for a more efficient storage.
We now expect country codes to be mapped to unique indexes, so that "AA" has an index of 0 and "ZZ" has an index of 675.
So, instead of a Country code list, it now expects a country index list. 
This information is then stored in three uint256 considering that the country index 0 corresponds to the first bit of the first integer. 
In case of "PT", the country index corresponds to 409 which translates to the (409-256) = 153th bit of the second integer flipped to 1.
Considering we also want to add "BR" country code, this corresponds to index 43, thus the 43th bit of the first integer is flipped to 1.