### PR TITLE
Documentation/release notes

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,14 @@
+{
+	"branch":"master",
+	"verifyConditions": [
+	 	"@semantic-release/github"
+	],
+	"repositoryUrl":"git@github.com:AppStoreFoundation/asf-contracts.git",
+	"prepare": [
+		""
+	],
+	"publish": [
+	 	"@semantic-release/github"
+	],
+	"noCi" : true
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "web3": "^1.0.0-beta.34"
   },
   "devDependencies": {
+    "semantic-release": "^15.5.1",
     "solidity-coverage": "^0.5.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "web3": "^1.0.0-beta.34"
   },
   "devDependencies": {
+    "cz-conventional-changelog": "^2.1.0",
+    "semantic-release": "^15.5.1",
     "solidity-coverage": "^0.5.4"
   },
   "scripts": {
@@ -33,5 +35,10 @@
     "asf",
     "appcoins"
   ],
-  "pre-commit": "lint"
+  "pre-commit": "lint",
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
 }


### PR DESCRIPTION
Need to run `npm install`.

### Publishing a release

1.  Generate a personal access token with the following permissions:
![accesstoken](https://user-images.githubusercontent.com/5559074/41228247-9854cfa4-6d6f-11e8-9d45-ddb31270b4eb.png)

2. Add your access token as global variable `GH_TOKEN`

3. On `master` branch execute `./node_modules/.bin/semantic-release`

4. A new release should appear on Github with the respective version update and release notes.

### Commit message template
Each commit message should now be following the template described on the project's [wiki](https://github.com/AppStoreFoundation/asf-contracts/wiki/Contributing-to-AppCoins-Protocol-smart-contracts#commit-message-conventions).
To ease the process you can use [commitizen](https://github.com/commitizen/cz-cli), instead of calling `git commit`, just use `git-cz` or install `commitizen` as global with npm and use `git cz`.
As example:
![example](https://user-images.githubusercontent.com/5559074/41228835-a442ab68-6d71-11e8-8a6e-0907f8384056.png)

Generates the following commit:
![commit](https://user-images.githubusercontent.com/5559074/41228871-d2c4cac0-6d71-11e8-8e37-1d9d4ad677cb.png)

