### PR TITLE
Fix/verify PoA length

### DIFF
--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -28,6 +28,8 @@ contract Advertisement {
         uint walletDailyConversions;
     }
 
+    uint constant expectedPoALength = 12;
+
     ValidationRules public rules;
     bytes32[] bidIdList;
     mapping (bytes32 => CampaignLibrary.Campaign) campaigns;
@@ -174,6 +176,11 @@ contract Advertisement {
         if(!isCampaignValid(bidId)){
             emit Error(
                 "registerPoA","Registering a Proof of attention to a invalid campaign");
+            return;
+        }
+
+        if(timestampList.length != expectedPoALength){
+            emit Error("registerPoA","Proof-of-attention should have exactly 12 proofs");
             return;
         }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "web3": "^1.0.0-beta.34"
   },
   "devDependencies": {
+    "cz-conventional-changelog": "^2.1.0",
     "solidity-coverage": "^0.5.4"
   },
   "scripts": {
@@ -33,5 +34,10 @@
     "asf",
     "appcoins"
   ],
-  "pre-commit": "lint"
+  "pre-commit": "lint",
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
 }

--- a/test/advertisement.js
+++ b/test/advertisement.js
@@ -304,4 +304,19 @@ contract('Advertisement', function(accounts) {
 
 	})
 
+	it('should revert registerPoA and emit an error event if PoA pairs are not exactly 12', async () => {
+		var userInitBalance = await TestUtils.getBalance(accounts[0]);
+		
+		examplePoA.timestamp.pop();
+		examplePoA.nonce.pop();
+
+		await TestUtils.expectErrorMessageTest("Proof-of-attention should have exactly 12 proofs", async () => {
+			await addInstance.registerPoA(examplePoA.packageName,examplePoA.bid,examplePoA.timestamp,examplePoA.nonce,accounts[1],accounts[2],walletName);
+		});
+
+		var newUserBalance = await TestUtils.getBalance(accounts[0]);
+		expect(userInitBalance).to.be.equal(newUserBalance);
+
+	})
+
 });


### PR DESCRIPTION
A bug was found on register PoA as it was not verifying if the Proof-of-attention had an exact length of 12.