### PR TITLE
Refactor/campaign storage

### DIFF
--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -32,7 +32,6 @@ contract Advertisement {
 
     ValidationRules public rules;
     bytes32[] bidIdList;
-    mapping (bytes32 => CampaignLibrary.Campaign) campaigns;
     AppCoins appc;
     AdvertisementStorage advertisementStorage;
     address public owner;
@@ -46,7 +45,15 @@ contract Advertisement {
 
     event PoARegistered(bytes32 bidId, string packageName,uint64[] timestampList,uint64[] nonceList,string walletName);
     event Error(string func, string message);
-
+    event CampaignInformation
+        (
+            bytes32 bidId,
+            address  owner,
+            string ipValidator,
+            string packageName,
+            uint[3] countries,
+            uint[] vercodes
+    ); 
     /**
     * Constructor function
     *
@@ -83,7 +90,7 @@ contract Advertisement {
     */
     function createCampaign (
         string packageName,
-        uint[] countries,
+        uint[3] countries,
         uint[] vercodes,
         uint price,
         uint budget,
@@ -96,14 +103,9 @@ contract Advertisement {
         
         CampaignLibrary.Campaign memory newCampaign;
 
-        newCampaign.filters.packageName = packageName;
-        newCampaign.filters.vercodes = vercodes;
         newCampaign.price = price;
         newCampaign.startDate = startDate;
         newCampaign.endDate = endDate;
-
-        (newCampaign.filters.countries[0],newCampaign.filters.countries[1],newCampaign.filters.countries[2]) = 
-            CampaignLibrary.convertCountryIndexToBytes(countries);
 
         //Transfers the budget to contract address
         if(appc.allowance(msg.sender, address(this)) < budget){
@@ -119,7 +121,14 @@ contract Advertisement {
         newCampaign.bidId = uintToBytes(bidIdList.length);
         addCampaign(newCampaign);
 
-    }
+        emit CampaignInformation(
+            newCampaign.bidId, 
+            newCampaign.owner,
+            "", // ipValidator field
+            packageName,
+            countries,
+            vercodes);
+    }   
 
     function addCampaign(CampaignLibrary.Campaign campaign) internal {
 
@@ -134,15 +143,9 @@ contract Advertisement {
             campaign.startDate,
             campaign.endDate,
             campaign.valid,
-            campaign.owner,
-            campaign.ipValidator
+            campaign.owner
         );
-        advertisementStorage.setCampaignFilters(
-            campaign.bidId,
-            campaign.filters.packageName,
-            campaign.filters.countries,
-            campaign.filters.vercodes
-        );
+
     }
 
     function registerPoA (
@@ -211,18 +214,6 @@ contract Advertisement {
 
     function getCampaignValidity(bytes32 bidId) public view returns(bool){
         return advertisementStorage.getCampaignValidById(bidId);
-    }
-
-    function getPackageNameOfCampaign (bytes32 bidId) public view returns(string) {
-        return advertisementStorage.getCampaignPackageNameById(bidId);
-    }
-
-    function getCountriesOfCampaign (bytes32 bidId) public view returns(uint[3]){
-        return advertisementStorage.getCampaignCountriesById(bidId);
-    }
-
-    function getVercodesOfCampaign (bytes32 bidId) public view returns(uint[]) {
-        return advertisementStorage.getCampaignVercodesById(bidId);
     }
 
     function getPriceOfCampaign (bytes32 bidId) public view returns(uint) {

--- a/contracts/AdvertisementStorage.sol
+++ b/contracts/AdvertisementStorage.sol
@@ -27,11 +27,7 @@ contract AdvertisementStorage {
             uint startDate,
             uint endDate,
             bool valid,
-            address  owner,
-            string ipValidator,
-            string packageName,
-            uint[3] countries,
-            uint[] vercodes
+            address owner
     );
 
     event CampaignUpdated
@@ -42,11 +38,7 @@ contract AdvertisementStorage {
             uint startDate,
             uint endDate,
             bool valid,
-            address  owner,
-            string ipValidator,
-            string packageName,
-            uint[3] countries,
-            uint[] vercodes
+            address  owner
     );
 
     function AdvertisementStorage() public {
@@ -69,11 +61,7 @@ contract AdvertisementStorage {
             uint,
             uint,
             bool,
-            address,
-            string,
-            string,
-            uint[3],
-            uint[]
+            address
         ) {
 
         CampaignLibrary.Campaign storage campaign = campaigns[campaignId];
@@ -85,11 +73,7 @@ contract AdvertisementStorage {
             campaign.startDate,
             campaign.endDate,
             campaign.valid,
-            campaign.owner,
-            campaign.ipValidator,
-            campaign.filters.packageName,
-            campaign.filters.countries,
-            campaign.filters.vercodes
+            campaign.owner
         );
     }
 
@@ -101,8 +85,7 @@ contract AdvertisementStorage {
         uint startDate,
         uint endDate,
         bool valid,
-        address owner,
-        string ipValidator
+        address owner
     )
     public
     onlyAllowedAddress {
@@ -116,34 +99,13 @@ contract AdvertisementStorage {
             startDate: startDate,
             endDate: endDate,
             valid: valid,
-            owner: owner,
-            ipValidator: ipValidator,
-            filters: campaign.filters
+            owner: owner
         });
 
-        emitEvent(campaigns[campaign.bidId]);
+        emitEvent(campaign);
 
         campaigns[campaign.bidId] = campaign;
-    }
-
-    function setCampaignFilters (
-        bytes32 bidId,
-        string packageName,
-        uint[3] countries,
-        uint[] vercodes
-    )
-    public
-    onlyAllowedAddress {
-
-        CampaignLibrary.Campaign memory campaign = campaigns[bidId];
-
-        campaign.filters.packageName = packageName;
-        campaign.filters.countries = countries;
-        campaign.filters.vercodes = vercodes;
-
-        emitEvent(campaigns[campaign.bidId]);
-
-        campaigns[campaign.bidId] = campaign;
+        
     }
 
     function getCampaignPriceById(bytes32 bidId)
@@ -236,66 +198,6 @@ contract AdvertisementStorage {
         emitEvent(campaigns[bidId]);
     }
 
-    function getCampaignCountriesById(bytes32 bidId)
-        public
-        view
-        returns (uint[3]) {
-        return campaigns[bidId].filters.countries;
-    }
-
-    function setCampaignCountriesById(bytes32 bidId, uint[3] newCountries)
-        public
-        onlyAllowedAddress
-        {
-        campaigns[bidId].filters.countries = newCountries;
-        emitEvent(campaigns[bidId]);
-    }
-
-    function getCampaignPackageNameById(bytes32 bidId)
-        public
-        view
-        returns (string) {
-        return campaigns[bidId].filters.packageName;
-    }
-
-    function setCampaignPackageNameById(bytes32 bidId, string newPackageName)
-        public
-        onlyAllowedAddress
-        {
-        campaigns[bidId].filters.packageName = newPackageName;
-        emitEvent(campaigns[bidId]);
-    }
-
-    function getCampaignVercodesById(bytes32 bidId)
-        public
-        view
-        returns (uint[]) {
-        return campaigns[bidId].filters.vercodes;
-    }
-
-    function setCampaignVercodesById(bytes32 bidId, uint[] newVercodes)
-        public
-        onlyAllowedAddress
-        {
-        campaigns[bidId].filters.vercodes = newVercodes;
-        emitEvent(campaigns[bidId]);
-    }
-
-    function getCampaignIpValidatorById(bytes32 bidId)
-        public
-        view
-        returns (string) {
-        return campaigns[bidId].ipValidator;
-    }
-
-    function setCampaignIpValidatorById(bytes32 bidId, string newIpValidator)
-        public
-        onlyAllowedAddress
-        {
-        campaigns[bidId].ipValidator = newIpValidator;
-        emitEvent(campaigns[bidId]);
-    }
-
     function emitEvent(CampaignLibrary.Campaign campaign) private {
 
         if (campaigns[campaign.bidId].bidId == 0x0) {
@@ -306,11 +208,7 @@ contract AdvertisementStorage {
                 campaign.startDate,
                 campaign.endDate,
                 campaign.valid,
-                campaign.owner,
-                campaign.ipValidator,
-                campaign.filters.packageName,
-                campaign.filters.countries,
-                campaign.filters.vercodes
+                campaign.owner
             );
         } else {
             emit CampaignUpdated(
@@ -320,11 +218,7 @@ contract AdvertisementStorage {
                 campaign.startDate,
                 campaign.endDate,
                 campaign.valid,
-                campaign.owner,
-                campaign.ipValidator,
-                campaign.filters.packageName,
-                campaign.filters.countries,
-                campaign.filters.vercodes
+                campaign.owner
             );
         }
     }

--- a/contracts/lib/CampaignLibrary.sol
+++ b/contracts/lib/CampaignLibrary.sol
@@ -3,12 +3,6 @@ pragma solidity ^0.4.19;
 
 library CampaignLibrary {
 
-    struct Filters {
-        uint[3] countries;
-        string packageName;
-        uint[] vercodes;
-    }
-
     struct Campaign {
         bytes32 bidId;
         uint price;
@@ -17,8 +11,6 @@ library CampaignLibrary {
         uint endDate;
         bool valid;
         address  owner;
-        Filters filters;
-        string ipValidator;
     }
 
     function convertCountryIndexToBytes(uint[] countries) internal returns (uint,uint,uint){

--- a/test/advertisement.js
+++ b/test/advertisement.js
@@ -178,8 +178,8 @@ contract('Advertisement', function(accounts) {
 		await appcInstance.approve(addInstance.address,campaignBudget);
 		var eventsStorage = AdvertisementStorageInstance.allEvents();
 		var eventsInfo = addInstance.allEvents();
-
-		await addInstance.createCampaign("com.instagram.android",countryList,[1,2],campaignPrice,campaignBudget,20,1922838059980);
+		var packageName1 = "com.instagram.android";
+		await addInstance.createCampaign(packageName1,countryList,[1,2],campaignPrice,campaignBudget,20,1922838059980);
 		
 		var eventStorageLog = await new Promise(
 				function(resolve, reject){
@@ -195,12 +195,15 @@ contract('Advertisement', function(accounts) {
 	    assert.equal(eventStorageLog.args.price,campaignPrice,"Price on campaign create event is not correct");
 	    assert.equal(eventStorageLog.args.budget,campaignBudget,"Budget on campaign create event is not correct");
 	    assert.equal(eventStorageLog.args.startDate,startDate,"Start date on campaign create event is not correct");
-	    assert.equal(eventStorageLog.args.finishDate,finishDate,"Finish date on campaign create event is not correct");
+	    assert.equal(eventStorageLog.args.endDate,endDate,"Finish date on campaign create event is not correct");
 
 		assert.equal(eventInfoLog.event,"CampaignInformation", "Event must be a CampaignInformation event");
-	    assert.equal(eventStorageLog.args.bidId,bid,"BidId on campaign info event is not correct");
-	    assert.equal(eventStorageLog.args.owner,accounts[0],"owner on campaign info event is not correct");
-	    assert.equal(eventStorageLog.args.packageName,packageName,"Package name on campaign info event is not correct");
+	    assert.equal(eventInfoLog.args.bidId,bid,"BidId on campaign info event is not correct");
+	    assert.equal(eventInfoLog.args.owner,accounts[0],"owner on campaign info event is not correct");
+	    assert.equal(eventInfoLog.args.packageName,packageName1,"Package name on campaign info event is not correct");
+	    assert.equal(eventInfoLog.args.countries[0],countryList[0],"Countries 1 on campaign info event are not correct");
+	    assert.equal(eventInfoLog.args.countries[1],countryList[1],"Countries 2 on campaign info event are not correct");
+	    assert.equal(eventInfoLog.args.countries[2],countryList[2],"Countries 3 on campaign info event are not correct");
 
 		
 		var budget = await addInstance.getBudgetOfCampaign(bid);

--- a/test/advertisement.js
+++ b/test/advertisement.js
@@ -212,7 +212,7 @@ contract('Advertisement', function(accounts) {
 	    assert.equal(eventInfoLog.args.countries[2],countryList[2],"Countries 3 on campaign info event are not correct");
 
 		
-		var budget = await addInstance.getBudgetOfCampaign(bid);
+		var budget = await addInstance.getBudgetOfCampaign.call(bid);
 		
 		await addInstance.createCampaign("com.instagram.android",countryList,[1,2],campaignPrice,campaignBudget,20,1922838059980);
 		
@@ -441,7 +441,7 @@ contract('Advertisement', function(accounts) {
 		await appcInstance.transfer(accounts[1],campaignBudget);
 		await adFinanceInstance.setAdsContractAddress(addInstance.address);
 
-		var budget = await addInstance.getBudgetOfCampaign(examplePoA.bid);
+		var budget = await addInstance.getBudgetOfCampaign.call(examplePoA.bid);
 		
 		expect(JSON.parse(budget)).to.be.equal(campaignBudget,"Campaign budget is incorrect");
 

--- a/test/advertisementStorage.js
+++ b/test/advertisementStorage.js
@@ -14,13 +14,7 @@ var testCampaign = {
     startDate: 500000,
     endDate: 600000,
     valid: true,
-    owner: '0x1DD02B96E9D55E16c646d2F21CA93A705ac667Bf',
-    ipValidator: 1,
-    filters: {
-        packageName: "com.test.pn",
-        countries: [409], // PT
-        vercodes: [1, 2]
-    }
+    owner: '0x1DD02B96E9D55E16c646d2F21CA93A705ac667Bf'
 };
 
 var expectRevert = RegExp('revert');
@@ -45,20 +39,12 @@ contract('AdvertisementStorage', function(accounts) {
             testCampaign.endDate,
             testCampaign.valid,
             testCampaign.owner,
-            testCampaign.ipValidator,
             { from: allowedAddress }
         );
-        await AdvertisementStorageInstance.setCampaignFilters(
-            testCampaign.bidId,
-            testCampaign.filters.packageName,
-            testCampaign.filters.countries,
-            testCampaign.filters.vercodes,
-            { from: allowedAddress }
-        );
+       
+        var advertStartDate = await AdvertisementStorageInstance.getCampaignStartDateById(testCampaign.bidId);
 
-        var advertPackageName = await AdvertisementStorageInstance.getCampaignPackageNameById(testCampaign.bidId);
-
-        expect(advertPackageName).to.be.equal(testCampaign.filters.packageName, "Successfully saved the campaign");
+        expect(JSON.parse(advertStartDate)).to.be.equal(testCampaign.startDate, "Campaign was not saved");
 
     })
 
@@ -75,7 +61,6 @@ contract('AdvertisementStorage', function(accounts) {
             testCampaign.endDate,
             testCampaign.valid,
             testCampaign.owner,
-            testCampaign.ipValidator,
             { from: invalidAddress }
         ).catch(
     		(err) => {

--- a/test/advertisementStorage.js
+++ b/test/advertisementStorage.js
@@ -41,8 +41,8 @@ contract('AdvertisementStorage', function(accounts) {
             testCampaign.owner,
             { from: allowedAddress }
         );
-               
-        var advertStartDate = await AdvertisementStorageInstance.getCampaignStartDateById(testCampaign.bidId);
+
+        var advertStartDate = await AdvertisementStorageInstance.getCampaignStartDateById.call(testCampaign.bidId);
 
         expect(JSON.parse(advertStartDate)).to.be.equal(testCampaign.startDate, "Campaign was not saved");
 


### PR DESCRIPTION
This PR carries some **breaking changes** as information like Package Name, vercodes and Countries are not longer stored by Advertisement storage.

The country code conversion to integer is still present but it's no longer used in the contracts. Register PoA is also still present. 

Considering gas cost, this implementation reduces gas from 466716 gas to 203650 gas. This represents a 56% reduction on gas when creating a campaign.