### PR TITLE
Fix/advertisement storage events

### DIFF
--- a/contracts/AdvertisementStorage.sol
+++ b/contracts/AdvertisementStorage.sol
@@ -200,7 +200,7 @@ contract AdvertisementStorage {
 
     function emitEvent(CampaignLibrary.Campaign campaign) private {
 
-        if (campaigns[campaign.bidId].bidId == 0x0) {
+        if (campaigns[campaign.bidId].owner == 0x0) {
             emit CampaignCreated(
                 campaign.bidId,
                 campaign.price,


### PR DESCRIPTION
A Campaign Created event is emitted when an update on a campaign with bidId 0x0, a Campaign Update event should be emitted instead.

The way the campaign existence is checked was changed.