### PR TITLE
Revert "[new] add return to registerPoa"

### DIFF
--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -69,17 +69,17 @@ contract Advertisement {
 
     function upgradeFinance (address addrAdverFinance) public onlyOwner {
         AdvertisementFinance newAdvFinance = AdvertisementFinance(addrAdverFinance);
-        Map storage devBalance;
+        Map storage devBalance;    
 
         for(uint i = 0; i < bidIdList.length; i++) {
             address dev = advertisementStorage.getCampaignOwnerById(bidIdList[i]);
-
+            
             if(devBalance.balance[dev] == 0){
                 devBalance.devs.push(dev);
             }
-
+            
             devBalance.balance[dev] += advertisementStorage.getCampaignBudgetById(bidIdList[i]);
-        }
+        }        
 
         for(i = 0; i < devBalance.devs.length; i++) {
             advertisementFinance.pay(devBalance.devs[i],address(newAdvFinance),devBalance.balance[devBalance.devs[i]]);
@@ -196,23 +196,23 @@ contract Advertisement {
         string packageName, bytes32 bidId,
         uint64[] timestampList, uint64[] nonces,
         address appstore, address oem,
-        string walletName, bytes2 countryCode) external returns(bool) {
+        string walletName, bytes2 countryCode) external {
 
         if(!isCampaignValid(bidId)){
             emit Error(
                 "registerPoA","Registering a Proof of attention to a invalid campaign");
-            return false;
+            return;
         }
 
         if(timestampList.length != expectedPoALength){
             emit Error("registerPoA","Proof-of-attention should have exactly 12 proofs");
-            return false;
+            return;
         }
 
         if(timestampList.length != nonces.length){
             emit Error(
                 "registerPoA","Nounce list and timestamp list must have same length");
-            return false;
+            return;
         }
         //Expect ordered array arranged in ascending order
         for (uint i = 0; i < timestampList.length - 1; i++) {
@@ -220,20 +220,20 @@ contract Advertisement {
             if((timestampDiff / 1000) != 10){
                 emit Error(
                     "registerPoA","Timestamps should be spaced exactly 10 secounds");
-                return false;
+                return;
             }
         }
 
         /* if(!areNoncesValid(bytes(packageName), timestampList, nonces)){
             emit Error(
                 "registerPoA","Incorrect nounces for submited proof of attention");
-            return false;
+            return;
         } */
 
         if(userAttributions[msg.sender][bidId]){
             emit Error(
                 "registerPoA","User already registered a proof of attention for this campaign");
-            return false;
+            return;
         }
         //atribute
         userAttributions[msg.sender][bidId] = true;
@@ -241,8 +241,6 @@ contract Advertisement {
         payFromCampaign(bidId, appstore, oem);
 
         emit PoARegistered(bidId, packageName, timestampList, nonces, walletName, countryCode);
-
-        return true;
     }
 
     function cancelCampaign (bytes32 bidId) public {


### PR DESCRIPTION
Reverts AppStoreFoundation/asf-contracts#73

Solidity as a restriction in the amount of variables that we can use in a function, I am still trying to find an alterantive, in the meanwhile, i will leave the revert here in case we need to deploy a new contract.