### PR TITLE
Refactor/contracts as ownable

### DIFF
--- a/contracts/AddressProxy.sol
+++ b/contracts/AddressProxy.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.19;
 
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 /**
 @title AddressProxy contract
 @author App Store Foundation
@@ -7,7 +9,7 @@ pragma solidity ^0.4.19;
 version's contracts deployed to the network.
  */
 
-contract AddressProxy {
+contract AddressProxy is Ownable {
 
     struct ContractAddress {
         bytes32 id;
@@ -17,20 +19,13 @@ contract AddressProxy {
         uint updatedTime;
     }
 
-    address public owner;
     mapping(bytes32 => ContractAddress) private contractsAddress;
     bytes32[] public availableIds;
-
-    modifier onlyOwner() {
-        require(msg.sender == owner);
-        _;
-    }
 
     event AddressCreated(bytes32 id, string name, address at, uint createdTime, uint updatedTime);
     event AddressUpdated(bytes32 id, string name, address at, uint createdTime, uint updatedTime);
 
     function AddressProxy() public {
-        owner = msg.sender;
     }
 
 

--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -83,15 +83,18 @@ contract Advertisement {
     function upgradeFinance (address addrAdverFinance) public onlyOwner {
         AdvertisementFinance newAdvFinance = AdvertisementFinance(addrAdverFinance);
         Map storage devBalance;    
+        address dev; 
+        uint balance;
 
         for(uint i = 0; i < bidIdList.length; i++) {
-            address dev = advertisementStorage.getCampaignOwnerById(bidIdList[i]);
-            
+
+            (,,balance,,,,dev) = advertisementStorage.getCampaign(bidIdList[i]);
+
             if(devBalance.balance[dev] == 0){
                 devBalance.devs.push(dev);
             }
             
-            devBalance.balance[dev] += advertisementStorage.getCampaignBudgetById(bidIdList[i]);
+            devBalance.balance[dev] += balance;
         }        
 
         for(i = 0; i < devBalance.devs.length; i++) {

--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -66,11 +66,6 @@ contract Advertisement {
         advertisementFinance = AdvertisementFinance(_addrAdverFinance);
     }
 
-    struct Map {
-        mapping (address => uint256) balance;
-        address[] devs;
-    }
-
     /**
     @notice Upgrade finance contract used by this contract
     @dev
@@ -81,26 +76,16 @@ contract Advertisement {
     @param addrAdverFinance Address of the new Advertisement Finance contract 
     */
     function upgradeFinance (address addrAdverFinance) public onlyOwner {
-        AdvertisementFinance newAdvFinance = AdvertisementFinance(addrAdverFinance);
-        Map storage devBalance;    
-        address dev; 
-        uint balance;
+        AdvertisementFinance newAdvFinance = AdvertisementFinance(addrAdverFinance);        
 
-        for(uint i = 0; i < bidIdList.length; i++) {
+        address[] memory devList = advertisementFinance.getDeveloperList();
 
-            (,,balance,,,,dev) = advertisementStorage.getCampaign(bidIdList[i]);
-
-            if(devBalance.balance[dev] == 0){
-                devBalance.devs.push(dev);
-            }
-            
-            devBalance.balance[dev] += balance;
-        }        
-
-        for(i = 0; i < devBalance.devs.length; i++) {
-            advertisementFinance.pay(devBalance.devs[i],address(newAdvFinance),devBalance.balance[devBalance.devs[i]]);
-            newAdvFinance.increaseBalance(devBalance.devs[i],devBalance.balance[devBalance.devs[i]]);
+        for(uint i = 0; i < devList.length; i++){
+            uint balance = advertisementFinance.getDeveloperBalance(devList[i]);
+            advertisementFinance.pay(devList[i],address(newAdvFinance),balance);
+            newAdvFinance.increaseBalance(devList[i],balance);
         }
+
 
         uint256 oldBalance = appc.balances(address(advertisementFinance));
 

--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -6,13 +6,15 @@ import "./AdvertisementStorage.sol";
 import "./AdvertisementFinance.sol";
 import "./AppCoins.sol";
 
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 /**
 @title Advertisement contract
 @author App Store Foundation
 @dev The Advertisement contract collects campaigns registered by developers and executes payments 
 to users using campaign registered applications after proof of Attention.
  */
-contract Advertisement {
+contract Advertisement is Ownable {
 
     struct ValidationRules {
         bool vercode;
@@ -29,13 +31,8 @@ contract Advertisement {
     AppCoins appc;
     AdvertisementStorage advertisementStorage;
     AdvertisementFinance advertisementFinance;
-    address public owner;
-    mapping (address => mapping (bytes32 => bool)) userAttributions;
 
-    modifier onlyOwner() {
-        require(msg.sender == owner);
-        _;
-    }
+    mapping (address => mapping (bytes32 => bool)) userAttributions;
 
 
     event PoARegistered(bytes32 bidId, string packageName,uint64[] timestampList,uint64[] nonceList,string walletName, bytes2 countryCode);
@@ -60,7 +57,7 @@ contract Advertisement {
     */
     function Advertisement (address _addrAppc, address _addrAdverStorage, address _addrAdverFinance) public {
         rules = ValidationRules(false, true, true, 2, 1);
-        owner = msg.sender;
+
         appc = AppCoins(_addrAppc);
         advertisementStorage = AdvertisementStorage(_addrAdverStorage);
         advertisementFinance = AdvertisementFinance(_addrAdverFinance);

--- a/contracts/AdvertisementFinance.sol
+++ b/contracts/AdvertisementFinance.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.21;
 
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 import "./AppCoins.sol";
 import "./Advertisement.sol";
 
@@ -10,21 +12,16 @@ import "./Advertisement.sol";
 Advertisemnt contract. This contract is responsible for storing all the amount of AppCoins destined 
 to user aquisition campaigns.
 */
-contract AdvertisementFinance {
+contract AdvertisementFinance is Ownable {
 
     mapping (address => uint256) balanceDevelopers;
     mapping (address => bool) developerExists;
     
     address[] developers;
-    address owner;
     address advertisementContract;
     address advStorageContract;
     AppCoins appc;
 
-    modifier onlyOwner() { 
-        require(owner == msg.sender); 
-        _; 
-    }
 
     modifier onlyAds() { 
         require(advertisementContract == msg.sender); 
@@ -44,7 +41,6 @@ contract AdvertisementFinance {
     */
     function AdvertisementFinance (address _addrAppc) 
         public {
-        owner = msg.sender;
         appc = AppCoins(_addrAppc);
         advStorageContract = 0x0;
     }

--- a/contracts/AdvertisementFinance.sol
+++ b/contracts/AdvertisementFinance.sol
@@ -151,7 +151,26 @@ contract AdvertisementFinance {
             withdraw(developers[i],balanceDevelopers[developers[i]]);
         }
     }
-    
 
+    /**
+    @notice Get list of developers with coins stored in the contract 
+    @dev
+        This function can only be called by the Advertisement contract        
+    @return { '_devList' : ' List of developers registered in the contract'}
+    */
+    function getDeveloperList() public view onlyAds returns(address[] _devList){
+        return developers;
+    }
+
+    /**
+    @notice Get balance of coins stored in the contract by a specific developer
+    @dev
+        This function can only be called by the Advertisement contract
+    @param _dev Developer's address
+    @return { '_balance' : 'Balance of coins deposited in the contract by the address' }
+    */
+    function getDeveloperBalance(address _dev) public view onlyAds returns(uint256 _balance){
+        return balanceDevelopers[_dev];
+    }
 }	
 

--- a/contracts/AdvertisementStorage.sol
+++ b/contracts/AdvertisementStorage.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.19;
 
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 import  { CampaignLibrary } from "./lib/CampaignLibrary.sol";
 
 /**
@@ -9,16 +11,10 @@ import  { CampaignLibrary } from "./lib/CampaignLibrary.sol";
 Advertisement contract. This contract is responsible from storing information regardign user 
 aquisiton campaigns.
 */
-contract AdvertisementStorage {
+contract AdvertisementStorage is Ownable {
 
     mapping (bytes32 => CampaignLibrary.Campaign) campaigns;
     mapping (address => bool) allowedAddresses;
-    address public owner;
-
-    modifier onlyOwner() {
-        require(msg.sender == owner);
-        _;
-    }
 
     modifier onlyAllowedAddress() {
         require(allowedAddresses[msg.sender]);
@@ -53,7 +49,6 @@ contract AdvertisementStorage {
         Initializes contract and updates allowed addresses to interact with contract functions.
     */
     function AdvertisementStorage() public {
-        owner = msg.sender;
         allowedAddresses[msg.sender] = true;
     }
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "dotenv": "^5.0.1",
+    "openzeppelin-solidity": "1.12.0",
     "pre-commit": "^1.2.2",
     "solhint": "^1.2.1",
     "solium": "^1.1.7",
-    "truffle": "^4.1.11",
+    "truffle": "^4.1.14",
     "truffle-hdwallet-provider": "0.0.3",
     "typedarray-to-buffer": "^3.1.5",
     "web3": "^1.0.0-beta.35"


### PR DESCRIPTION
**This Pull Request depends on #78** 
- Add OpenZeppelin dependency
- Upgrades the truffle version to v4.1.14 in order to use Solidity v0.4.24 (required by OpenZeppelin)
- Removed onlyOwner modifiers and other references to contract owner, contracts now use Ownable contract getting modifiers (as onlyOwner) and methods from it.
 