### PR TITLE
Refactor/pay campaign

### DIFF
--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -121,7 +121,6 @@ contract Advertisement {
             cancelCampaign(bidIdList[i]);
         }
         delete bidIdList;
-        advertisementFinance.reset();
         advertisementFinance.setAdsStorageAddress(addrAdverStorage);
         advertisementStorage = AdvertisementStorage(addrAdverStorage);
     }

--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -304,7 +304,7 @@ contract Advertisement {
         //atribute
         userAttributions[msg.sender][bidId] = true;
 
-        payFromCampaign(bidId, appstore, oem);
+        payFromCampaign(bidId, msg.sender, appstore, oem);
 
         emit PoARegistered(bidId, packageName, timestampList, nonces, walletName, countryCode);
     }
@@ -434,7 +434,7 @@ contract Advertisement {
     @param appstore Address of the Appstore receiving it's share
     @param oem Address of the OEM receiving it's share
     */
-    function payFromCampaign (bytes32 bidId, address appstore, address oem) internal {
+    function payFromCampaign (bytes32 bidId, address user, address appstore, address oem) internal {
         uint devShare = 85;
         uint appstoreShare = 10;
         uint oemShare = 5;
@@ -448,7 +448,7 @@ contract Advertisement {
         require(budget >= price);
 
         //transfer to user, appstore and oem
-        advertisementFinance.pay(campaignOwner,msg.sender,division(price * devShare, 100));
+        advertisementFinance.pay(campaignOwner,user,division(price * devShare, 100));
         advertisementFinance.pay(campaignOwner,appstore,division(price * appstoreShare, 100));
         advertisementFinance.pay(campaignOwner,oem,division(price * oemShare, 100));
 

--- a/contracts/AdvertisementFinance.sol
+++ b/contracts/AdvertisementFinance.sol
@@ -121,6 +121,8 @@ contract AdvertisementFinance {
     function pay(address _developer, address _destination, uint256 _value) 
         public onlyAds{
 
+        require(balanceDevelopers[_developer] >= _value);
+
         appc.transfer( _destination, _value);
         balanceDevelopers[_developer] -= _value;
     }


### PR DESCRIPTION
Minor changes : 
 - `payFromCampaign` function was changed to receive the user's address in order for the function to be more generic
- `reset()` call to Finance contract was removed from `upgradeStorage` function because  `setAdsStorageAddress` function of the Finance contract already executes the reset function