### PR TITLE
Refactor/base advertisement

### DIFF
--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -7,6 +7,7 @@ import "./AdvertisementFinance.sol";
 import "./AppCoins.sol";
 
 import "./Base/Ownable.sol";
+import "./Base/BaseAdvertisement.sol";
 
 /**
 @title Advertisement contract
@@ -14,7 +15,7 @@ import "./Base/Ownable.sol";
 @dev The Advertisement contract collects campaigns registered by developers and executes payments 
 to users using campaign registered applications after proof of Attention.
  */
-contract Advertisement is Ownable {
+contract Advertisement is Ownable, BaseAdvertisement{
 
     struct ValidationRules {
         bool vercode;
@@ -27,25 +28,9 @@ contract Advertisement is Ownable {
     uint constant expectedPoALength = 12;
 
     ValidationRules public rules;
-    bytes32[] bidIdList;
-    AppCoins appc;
+
     AdvertisementStorage advertisementStorage;
     AdvertisementFinance advertisementFinance;
-
-    mapping (address => mapping (bytes32 => bool)) userAttributions;
-
-
-    event PoARegistered(bytes32 bidId, string packageName,uint64[] timestampList,uint64[] nonceList,string walletName, bytes2 countryCode);
-    event Error(string func, string message);
-    event CampaignInformation
-        (
-            bytes32 bidId,
-            address  owner,
-            string ipValidator,
-            string packageName,
-            uint[3] countries,
-            uint[] vercodes
-    );
 
     /**
     @notice Constructor function
@@ -55,10 +40,11 @@ contract Advertisement is Ownable {
     @param _addrAdverStorage Address of the Advertisement Storage contract to be used
     @param _addrAdverFinance Address of the Advertisement Finance contract to be used
     */
-    function Advertisement (address _addrAppc, address _addrAdverStorage, address _addrAdverFinance) public {
-        rules = ValidationRules(false, true, true, 2, 1);
+    function Advertisement (address _addrAppc, address _addrAdverStorage, address _addrAdverFinance) public 
+        BaseAdvertisement(_addrAppc)
+    {
 
-        appc = AppCoins(_addrAppc);
+        rules = ValidationRules(false, true, true, 2, 1);
         advertisementStorage = AdvertisementStorage(_addrAdverStorage);
         advertisementFinance = AdvertisementFinance(_addrAdverFinance);
     }
@@ -280,13 +266,13 @@ contract Advertisement is Ownable {
             return;
         } */
 
-        if(userAttributions[msg.sender][bidId]){
+        if(userAttributions[bidId][msg.sender] > 0){
             emit Error(
                 "registerPoA","User already registered a proof of attention for this campaign");
             return;
         }
         //atribute
-        userAttributions[msg.sender][bidId] = true;
+        userAttributions[bidId][msg.sender] += 1;
 
         payFromCampaign(bidId, msg.sender, appstore, oem);
 
@@ -380,16 +366,6 @@ contract Advertisement is Ownable {
     */
     function getOwnerOfCampaign (bytes32 bidId) public view returns(address campaignOwner) {
         return advertisementStorage.getCampaignOwnerById(bidId);
-    }
-
-    /**
-    @notice Get the list of Campaign BidIds registered in the contract
-    @dev
-        Returns the list of BidIds of the campaigns ever registered in the contract
-    @return { "bidIds" : "List of BidIds registered in the contract" }
-    */
-    function getBidIdList() public view returns(bytes32[] bidIds) {
-        return bidIdList;
     }
 
     /**

--- a/contracts/Base/BaseAdvertisement.sol
+++ b/contracts/Base/BaseAdvertisement.sol
@@ -2,7 +2,11 @@ pragma solidity ^0.4.24;
 
 import "../AppCoins.sol";
 
-
+/**
+@title Base Advertisement contract
+@author App Store Foundation
+@dev Abstract contract for user aquisition campaign contracts.
+ */
 contract BaseAdvertisement {
     
     AppCoins appc;

--- a/contracts/Base/BaseAdvertisement.sol
+++ b/contracts/Base/BaseAdvertisement.sol
@@ -1,0 +1,80 @@
+pragma solidity ^0.4.24;
+
+import "../AppCoins.sol";
+
+
+contract BaseAdvertisement {
+    
+    AppCoins appc;
+
+    mapping( bytes32 => mapping(address => uint256)) userAttributions;
+
+    bytes32[] bidIdList;
+
+    event PoARegistered(bytes32 bidId, string packageName,uint64[] timestampList,uint64[] nonceList,string walletName, bytes2 countryCode);
+    
+    event CampaignInformation
+        (
+            bytes32 bidId,
+            address  owner,
+            string ipValidator,
+            string packageName,
+            uint[3] countries,
+            uint[] vercodes
+    );
+
+    constructor(address _addrAppc) public {
+        appc = AppCoins(_addrAppc);
+    }
+
+    /**
+    @notice Creates a campaign 
+    @dev 
+        Method to create a campaign of user aquisition for a certain application.
+        This method will emit a Campaign Information event with every information 
+        provided in the arguments of this method.
+    @param packageName Package name of the appication subject to the user aquisition campaign
+    @param countries Encoded list of 3 integers intended to include every 
+    county where this campaign will be avaliable.
+    For more detain on this encoding refer to wiki documentation.
+    @param vercodes List of version codes to which the user aquisition campaign is applied.
+    @param price Value (in wei) the campaign owner pays for each proof-of-attention.
+    @param budget Total budget (in wei) the campaign owner will deposit 
+    to pay for the proof-of-attention.
+    @param startDate Date (in miliseconds) on which the campaign will start to be 
+    avaliable to users.
+    @param endDate Date (in miliseconds) on which the campaign will no longer be avaliable to users.
+    */
+
+    function createCampaign (
+        string packageName,
+        uint[3] countries,
+        uint[] vercodes,
+        uint price,
+        uint budget,
+        uint startDate,
+        uint endDate)
+        external;
+
+    /**
+    @notice Cancel a campaign and give the remaining budget to the campaign owner
+    @dev
+        When a campaing owner wants to cancel a campaign, the campaign owner needs 
+        to call this function. This function can only be called either by the campaign owner or by 
+        the Advertisement contract owner. This function results in campaign cancelation and 
+        retreival of the remaining budged to the respective campaign owner.
+    @param bidId Campaign id to which the cancelation referes to 
+     */
+    function cancelCampaign (bytes32 bidId) public;
+
+    /**
+    @notice Get the list of Campaign BidIds registered in the contract
+    @dev
+        Returns the list of BidIds of the campaigns ever registered in the contract
+    @return { "bidIds" : "List of BidIds registered in the contract" }
+    */
+    function getBidIdList() public view returns(bytes32[] bidIds) {
+        return bidIdList;
+    }
+
+}

--- a/contracts/ExtendedAdvertisement.sol
+++ b/contracts/ExtendedAdvertisement.sol
@@ -14,25 +14,25 @@ contract ExtendedAdvertisement is Whitelist, BaseAdvertisement {
         uint startDate,
         uint endDate)
         external 
-        onlyWhitelist(msg.sender)
+        onlyIfWhitelisted("createCampaign",msg.sender)
         {
-        emit Error("Function not implemented.");
+        emit Error("createCampaign","Function not implemented.");
         return;
     }
 
-    function cancelCampaign(bidId) 
+    function cancelCampaign(bytes32 bidId) 
         public 
-        onlyWhitelist(msg.sender)
+        onlyIfWhitelisted("createCampaign",msg.sender)
         {
-        emit Error("Function not implemented.");
+        emit Error("createCampaign","Function not implemented.");
         return;
     }
 
     function bulckRegisterPoA() 
         public 
-        onlyWhitelist(msg.sender)
+        onlyIfWhitelisted("createCampaign",msg.sender)
         {
-        emit Error("Function not implemented.");
+        emit Error("createCampaign","Function not implemented.");
         return;
     }
 

--- a/contracts/ExtendedAdvertisement.sol
+++ b/contracts/ExtendedAdvertisement.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.4.24;
+
+import "./Base/BaseAdvertisement.sol";
+import "./Base/Whitelist.sol";
+
+contract ExtendedAdvertisement is Whitelist, BaseAdvertisement {
+
+    function createCampaign (
+        string packageName,
+        uint[3] countries,
+        uint[] vercodes,
+        uint price,
+        uint budget,
+        uint startDate,
+        uint endDate)
+        external 
+        onlyWhitelist(msg.sender)
+        {
+        emit Error("Function not implemented.");
+        return;
+    }
+
+    function cancelCampaign(bidId) 
+        public 
+        onlyWhitelist(msg.sender)
+        {
+        emit Error("Function not implemented.");
+        return;
+    }
+
+    function bulckRegisterPoA() 
+        public 
+        onlyWhitelist(msg.sender)
+        {
+        emit Error("Function not implemented.");
+        return;
+    }
+
+}


### PR DESCRIPTION
Refactoring some of the `Advertisement` contract's code to a Base contract in order to extend further functionality to BDS campaigns in a new contract.

The user attribution mapping was changed in order to map user attributions by campaigns instead of campaigns attributed by user. Furthermore, attribution was changed from a boolean value to a integer. 

This includes the creation of a dummy `Extended Advertisement` contract which still requires full implementation to work.