### PR TITLE
Fix/whitelisted creating campaigns

### DIFF
--- a/contracts/AdvertisementFinance.sol
+++ b/contracts/AdvertisementFinance.sol
@@ -20,8 +20,8 @@ contract AdvertisementFinance is BaseFinance {
 
         require(balanceUsers[_user] >= _value);
 
-        appc.transfer( _destination, _value);
         balanceUsers[_user] -= _value;
+        appc.transfer( _destination, _value);
     }
 
 
@@ -29,8 +29,8 @@ contract AdvertisementFinance is BaseFinance {
 
         require(balanceUsers[_user] >= _value);
 
-        appc.transfer(_user, _value);
         balanceUsers[_user] -= _value;
+        appc.transfer(_user, _value);
     }
 
 }

--- a/contracts/ExtendedAdvertisement.sol
+++ b/contracts/ExtendedAdvertisement.sol
@@ -137,16 +137,12 @@ contract ExtendedAdvertisement is BaseAdvertisement, Whitelist {
         public 
         onlyIfWhitelisted("withdraw",msg.sender)
         {
-        uint256 balance = _getFinance().getUserBalance(msg.sender);
-        _getFinance().withdraw(msg.sender,balance);
+        uint256 balance = ExtendedFinance(address(_getFinance())).getRewardsBalance(msg.sender);
+        ExtendedFinance(address(_getFinance())).withdrawRewards(msg.sender,balance);
     }
 
-    function getBalance()
-        public 
-        onlyIfWhitelisted("withdraw",msg.sender)
-        returns (uint256 _balance)
-        {
-        return _getFinance().getUserBalance(msg.sender);    
+    function getRewardsBalance(address _user) public view returns (uint256 _balance) {
+        return ExtendedFinance(address(_getFinance())).getRewardsBalance(_user);
     }
 
     function getEndPointOfCampaign (bytes32 bidId) public view returns (string url){

--- a/contracts/ExtendedAdvertisement.sol
+++ b/contracts/ExtendedAdvertisement.sol
@@ -140,10 +140,23 @@ contract ExtendedAdvertisement is BaseAdvertisement, Whitelist {
         uint256 balance = ExtendedFinance(address(_getFinance())).getRewardsBalance(msg.sender);
         ExtendedFinance(address(_getFinance())).withdrawRewards(msg.sender,balance);
     }
-
+    /**
+    @notice Get user's balance of funds obtainded by rewards
+    @dev
+        Anyone can call this function and get the rewards balance of a certain user.
+    @param _user Address from which the balance refers to
+    @return { "_balance" : "" } */
     function getRewardsBalance(address _user) public view returns (uint256 _balance) {
         return ExtendedFinance(address(_getFinance())).getRewardsBalance(_user);
     }
+
+    /**
+    @notice Returns the signing Endpoint of a camapign
+    @dev
+        Function returning the Webservice URL responsible for validating and signing a PoA
+    @param bidId Campaign id to which the Endpoint is associated
+    @return { "url" : "Validation and signature endpoint"}
+    */
 
     function getEndPointOfCampaign (bytes32 bidId) public view returns (string url){
         return ExtendedAdvertisementStorage(address(_getStorage())).getCampaignEndPointById(bidId);

--- a/contracts/ExtendedAdvertisement.sol
+++ b/contracts/ExtendedAdvertisement.sol
@@ -23,6 +23,7 @@ contract ExtendedAdvertisement is BaseAdvertisement, Whitelist {
 
     constructor(address _addrAppc, address _addrAdverStorage, address _addrAdverFinance) public 
         BaseAdvertisement(_addrAppc,_addrAdverStorage,_addrAdverFinance) {
+        addAddressToWhitelist(msg.sender);
     }
 
 

--- a/contracts/ExtendedFinance.sol
+++ b/contracts/ExtendedFinance.sol
@@ -35,4 +35,12 @@ contract ExtendedFinance is BaseFinance {
 
     }
 
+    function withdrawRewards(address _user, uint256 _value) public onlyOwnerOrAllowed {
+        withdraw(_user, _value);
+    }
+
+    function getRewardsBalance(address _user) public view onlyOwnerOrAllowed returns (uint256) {
+        return getUserBalance(_user);
+    }
+
 }

--- a/contracts/ExtendedFinance.sol
+++ b/contracts/ExtendedFinance.sol
@@ -37,14 +37,27 @@ contract ExtendedFinance is BaseFinance {
 
     }
 
+    /**
+    @notice Withdraws user's rewards
+    @dev
+        Function to transfer a certain user's rewards to his address 
+    @param _user Address who's rewards will be withdrawn
+    @param _value Value of the withdraws which will be transfered to the user 
+    */
     function withdrawRewards(address _user, uint256 _value) public onlyOwnerOrAllowed {
         require(rewardedBalance[_user] >= _value);
 
         appc.transfer(_user, _value);
         rewardedBalance[_user] -= _value;
     }
-
-    function getRewardsBalance(address _user) public onlyOwnerOrAllowed returns (uint256) {
+    /**
+    @notice Get user's rewards balance
+    @dev
+        Function returning a user's rewards balance not yet withdrawn
+    @param _user Address of the user
+    @return { "_balance" : "Rewards balance of the user" }
+    */
+    function getRewardsBalance(address _user) public onlyOwnerOrAllowed returns (uint256 _balance) {
         return rewardedBalance[_user];
     }
 

--- a/contracts/ExtendedFinance.sol
+++ b/contracts/ExtendedFinance.sol
@@ -41,7 +41,7 @@ contract ExtendedFinance is BaseFinance {
         require(rewardedBalance[_user] >= _value);
 
         appc.transfer(_user, _value);
-        rewardedBalance[_user] += _value;
+        rewardedBalance[_user] -= _value;
     }
 
     function getRewardsBalance(address _user) public onlyOwnerOrAllowed returns (uint256) {

--- a/contracts/ExtendedFinance.sol
+++ b/contracts/ExtendedFinance.sol
@@ -11,6 +11,8 @@ to user aquisition campaigns.
 */
 contract ExtendedFinance is BaseFinance {
 
+    mapping ( address => uint256 ) rewardedBalance;
+
     constructor(address _appc) public BaseFinance(_appc){
 
     }
@@ -22,7 +24,7 @@ contract ExtendedFinance is BaseFinance {
         require(balanceUsers[_user] >= _value);
 
         balanceUsers[_user] -= _value;
-        balanceUsers[_destination] += _value;
+        rewardedBalance[_destination] += _value;
     }
 
 
@@ -36,11 +38,14 @@ contract ExtendedFinance is BaseFinance {
     }
 
     function withdrawRewards(address _user, uint256 _value) public onlyOwnerOrAllowed {
-        withdraw(_user, _value);
+        require(rewardedBalance[_user] >= _value);
+
+        appc.transfer(_user, _value);
+        rewardedBalance[_user] += _value;
     }
 
-    function getRewardsBalance(address _user) public view onlyOwnerOrAllowed returns (uint256) {
-        return getUserBalance(_user);
+    function getRewardsBalance(address _user) public onlyOwnerOrAllowed returns (uint256) {
+        return rewardedBalance[_user];
     }
 
 }

--- a/contracts/ExtendedFinance.sol
+++ b/contracts/ExtendedFinance.sol
@@ -32,8 +32,8 @@ contract ExtendedFinance is BaseFinance {
 
         require(balanceUsers[_user] >= _value);
 
-        appc.transfer(_user, _value);
         balanceUsers[_user] -= _value;
+        appc.transfer(_user, _value);
 
     }
 
@@ -47,8 +47,8 @@ contract ExtendedFinance is BaseFinance {
     function withdrawRewards(address _user, uint256 _value) public onlyOwnerOrAllowed {
         require(rewardedBalance[_user] >= _value);
 
-        appc.transfer(_user, _value);
         rewardedBalance[_user] -= _value;
+        appc.transfer(_user, _value);
     }
     /**
     @notice Get user's rewards balance

--- a/test/extendedAdvertisement.js
+++ b/test/extendedAdvertisement.js
@@ -382,6 +382,19 @@ contract('ExtendedAdvertisement', function(accounts) {
 
 	})
 
+	it('should allow a whitelisted address to create a campaign in behalf of a user and still withdraw funds from rewards', async function () {
+		var bid = web3.utils.toHex("0x0000000000000000000000000000000000000000000000000000000000000002");
+		var initBalance = await TestUtils.getBalance(accounts[0]);
+		
+		await addInstance.bulkRegisterPoA(bid,0x02,0x02,1);
+		await addInstance.withdraw();
+		var finalBalance = await TestUtils.getBalance(accounts[0]);
+		expect(finalBalance).to.be.equal(initBalance-campaignPrice,"Balance was not withdrawn to user account");
+		userBalanceInContract = JSON.parse(await addInstance.getBalance());
+		expect(userBalanceInContract).to.be.equal(campaignBudget,"User should still have balance in contract for camapaigns");
+		
+	});
+
 	it('should allow to withdraw a balance', async function () {
 		var bid = web3.utils.toHex("0x0000000000000000000000000000000000000000000000000000000000000002");
 		var initBalance = await TestUtils.getBalance(accounts[2]);
@@ -395,9 +408,7 @@ contract('ExtendedAdvertisement', function(accounts) {
 					expect(finalContractBalance).to.equal(contractBalance-campaignPrice,"Contract balance was not updated");
 					expect(finalBalance).to.equal(initBalance+campaignPrice,"Balance was not withdrawn to user account");
 				});
-
 			});
-
 
 	});
 });

--- a/test/extendedAdvertisement.js
+++ b/test/extendedAdvertisement.js
@@ -51,7 +51,7 @@ contract('ExtendedAdvertisement', function(accounts) {
   		TestUtils.setAppCoinsInstance(appcInstance);
   		TestUtils.setContractInstance(addInstance);
 
-  		campaignPrice = 50000000000000000;
+  		campaignPrice = 500000000000000000;
   		campaignBudget = 1000000000000000000;
 
   		var countryList = []
@@ -246,7 +246,7 @@ contract('ExtendedAdvertisement', function(accounts) {
 		await addInstance.addAddressToWhitelist(accounts[2]);
 		return addInstance.bulkRegisterPoA.sendTransaction(bid,0x02,0x02,1,{from: accounts[2]}).then( async () => {
 			var contractFinalBalance = JSON.parse(await TestUtils.getBalance(adFinanceInstance.address));
-			var userVirtualBalance = JSON.parse(await addInstance.getBalance.call({from: accounts[2]}));
+			var userVirtualBalance = JSON.parse(await addInstance.getRewardsBalance.call(accounts[2],{from: accounts[2]}));
 			var campaignFinalBudget = JSON.parse(await addInstance.getBudgetOfCampaign.call(examplePoA.bid));
 
 			expect(contractFinalBalance).to.equal(contractBalance,"No appcoins should leave the finance contract");
@@ -325,9 +325,9 @@ contract('ExtendedAdvertisement', function(accounts) {
 		await AdvertisementStorageInstance.addAddressToWhitelist(addInstance.address);
 		await addInstance.addAddressToWhitelist(accounts[2]);
 
-		var initBalance = JSON.parse(await addInstance.getBalance.call({from: accounts[2]}));
+		var initBalance = JSON.parse(await addInstance.getRewardsBalance.call(accounts[2],{from: accounts[2]}));
 		return addInstance.bulkRegisterPoA.sendTransaction(bid,0x02,0x02,1,{from: accounts[2]}).then( async instance => {
-			var balance = JSON.parse(await addInstance.getBalance.call({from: accounts[2]}));
+			var balance = JSON.parse(await addInstance.getRewardsBalance.call(accounts[2],{from: accounts[2]}));
 			expect(balance).to.be.equal(campaignPrice+initBalance,'Campaign price was not transfered');
 		})
 	})
@@ -389,10 +389,8 @@ contract('ExtendedAdvertisement', function(accounts) {
 		await addInstance.bulkRegisterPoA(bid,0x02,0x02,1);
 		await addInstance.withdraw();
 		var finalBalance = await TestUtils.getBalance(accounts[0]);
-		expect(finalBalance).to.be.equal(initBalance-campaignPrice,"Balance was not withdrawn to user account");
-		userBalanceInContract = JSON.parse(await addInstance.getBalance());
-		expect(userBalanceInContract).to.be.equal(campaignBudget,"User should still have balance in contract for camapaigns");
-		
+
+		expect(finalBalance).to.be.equal(initBalance+campaignPrice,"Balance was not withdrawn to user account");
 	});
 
 	it('should allow to withdraw a balance', async function () {

--- a/test/extendedFinance.js
+++ b/test/extendedFinance.js
@@ -184,15 +184,17 @@ contract('ExtendedFinance', function(accounts) {
         await ExtendedFinanceInstance.increaseBalance(developer, budget,{ from: allowedAddress});
         
         var initcontractBalance = await TestUtils.getBalance(ExtendedFinanceInstance.address);
-        await ExtendedFinanceInstance.pay(developer, accounts[3], budget*0.1, { from: allowedAddress});
+        await ExtendedFinanceInstance.pay(developer, accounts[3], budget*0.5, { from: allowedAddress});
 
         var finalcontractBalance = await TestUtils.getBalance(ExtendedFinanceInstance.address);
         
         expect(initcontractBalance).to.be.equal(finalcontractBalance,"Contract balance should not change after pay function");
 
-        await ExtendedFinanceInstance.withdraw(accounts[3], budget*0.1, { from: allowedAddress });
+        var rewardBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance.call(accounts[3],{ from: allowedAddress}));
+    
+        await ExtendedFinanceInstance.withdrawRewards(accounts[3], rewardBalance, { from: allowedAddress });
         
-        expect(await TestUtils.getBalance(accounts[3])).to.be.equal(budget*0.1);
+        expect(await TestUtils.getBalance(accounts[3])).to.be.equal(rewardBalance);
   
     });
     
@@ -254,7 +256,8 @@ contract('ExtendedFinance', function(accounts) {
         await ExtendedFinanceInstance.increaseBalance(developer, budget,{ from: allowedAddress});
         
         await ExtendedFinanceInstance.pay(developer,developer,reward,{ from: allowedAddress});
-        var internalBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance(developer,{ from: allowedAddress}));
+        var internalBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance.call(developer,{ from: allowedAddress}));
+
         await ExtendedFinanceInstance.withdrawRewards(developer,internalBalance,{ from: allowedAddress});
         expect(await TestUtils.getBalance(developer)).to.be.equal(initDevBalance + reward, 'Developer should receive his share');
     });

--- a/test/extendedFinance.js
+++ b/test/extendedFinance.js
@@ -42,15 +42,23 @@ contract('ExtendedFinance', function(accounts) {
 
 
     it('should store a dev balance if it is done from a valid address', async function () {
-        var allowedAddress = accounts[1];
+        var allowedAddress = accounts[0];
         var budget = 50000000000000000;
         var developer = accounts[2];
-
+        var initBalance;
+        var finalBalance;
+        var initContractBalance = await TestUtils.getBalance(ExtendedFinanceInstance.address);
+        var finalContractBalance;
+        
         await ExtendedFinanceInstance.setAllowedAddress(allowedAddress);
-
+        initBalance = JSON.parse(await ExtendedFinanceInstance.getUserBalance.call(developer,{from: allowedAddress}));
         await appcInstance.transfer(ExtendedFinanceInstance.address, budget, { from: allowedAddress});
-
+        
         await ExtendedFinanceInstance.increaseBalance(developer, budget,{ from: allowedAddress});
+        finalContractBalance = await TestUtils.getBalance(ExtendedFinanceInstance.address);
+        finalBalance = JSON.parse(await ExtendedFinanceInstance.getUserBalance.call(developer,{from: allowedAddress}));
+        expect(finalBalance).to.be.equal(initBalance+budget,"Balance was not updated");
+        expect(finalContractBalance).to.be.equal(initContractBalance+budget,"Contract balance should have been updated");
 
     })
     it('should revert if the balance is updated by anyone other than the Advertisement Contract', async function () {
@@ -191,10 +199,12 @@ contract('ExtendedFinance', function(accounts) {
         expect(initcontractBalance).to.be.equal(finalcontractBalance,"Contract balance should not change after pay function");
 
         var rewardBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance.call(accounts[3],{ from: allowedAddress}));
-    
+        
         await ExtendedFinanceInstance.withdrawRewards(accounts[3], rewardBalance, { from: allowedAddress });
         
-        expect(await TestUtils.getBalance(accounts[3])).to.be.equal(rewardBalance);
+        var finalrewardBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance.call(accounts[3],{ from: allowedAddress}));
+        expect(finalrewardBalance).to.be.equal(0,"Reward balance not updated")
+        expect(await TestUtils.getBalance(accounts[3])).to.be.equal(rewardBalance,"Rewards were not transfered");
   
     });
     

--- a/test/extendedFinance.js
+++ b/test/extendedFinance.js
@@ -268,13 +268,13 @@ contract('ExtendedFinance', function(accounts) {
         
         await ExtendedFinanceInstance.pay(developer,developer,reward,{ from: allowedAddress});
         
-        initDevCampaignBalance = JSON.parse(await ExtendedFinanceInstance.getUserBalance(developer,{from: allowedAddress}));
+        initDevCampaignBalance = JSON.parse(await ExtendedFinanceInstance.getUserBalance.call(developer,{from: allowedAddress}));
         var internalBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance.call(developer,{ from: allowedAddress}));
         
         await ExtendedFinanceInstance.withdrawRewards(developer,internalBalance,{ from: allowedAddress});
         
         var internalfinalBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance.call(developer,{ from: allowedAddress}));
-        var finalDevCampaignBalance = JSON.parse(await ExtendedFinanceInstance.getUserBalance(developer,{from: allowedAddress}));
+        var finalDevCampaignBalance = JSON.parse(await ExtendedFinanceInstance.getUserBalance.call(developer,{from: allowedAddress}));
         
         expect(await TestUtils.getBalance(developer)).to.be.equal(initDevBalance + reward, 'Developer should receive his share');
         expect(internalfinalBalance).to.be.equal(0,'All rewards should have been withdrawn');

--- a/test/extendedFinance.js
+++ b/test/extendedFinance.js
@@ -241,5 +241,22 @@ contract('ExtendedFinance', function(accounts) {
         expect(await TestUtils.getBalance(developer)).to.be.equal(initDevBalance + budget, 'Developer should receive his share');
 
     })
+
+    it('should allow a user to withdraw rewards without taking funds destined to user\'s campaigns',async function(){
+        var allowedAddress = accounts[1];
+        var budget = 50000000000000000;
+        var reward = 5000000000000000;
+        var developer = accounts[4];
+        var initDevBalance =await TestUtils.getBalance(developer);
+
+        await ExtendedFinanceInstance.setAllowedAddress(allowedAddress);
+        await appcInstance.transfer(ExtendedFinanceInstance.address,budget);
+        await ExtendedFinanceInstance.increaseBalance(developer, budget,{ from: allowedAddress});
+        
+        await ExtendedFinanceInstance.pay(developer,developer,reward,{ from: allowedAddress});
+        var internalBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance(developer,{ from: allowedAddress}));
+        await ExtendedFinanceInstance.withdrawRewards(developer,internalBalance,{ from: allowedAddress});
+        expect(await TestUtils.getBalance(developer)).to.be.equal(initDevBalance + reward, 'Developer should receive his share');
+    });
     
 });

--- a/test/extendedFinance.js
+++ b/test/extendedFinance.js
@@ -250,16 +250,26 @@ contract('ExtendedFinance', function(accounts) {
         var reward = 5000000000000000;
         var developer = accounts[4];
         var initDevBalance =await TestUtils.getBalance(developer);
-
+        var initDevCampaignBalance;
+        
         await ExtendedFinanceInstance.setAllowedAddress(allowedAddress);
         await appcInstance.transfer(ExtendedFinanceInstance.address,budget);
         await ExtendedFinanceInstance.increaseBalance(developer, budget,{ from: allowedAddress});
         
         await ExtendedFinanceInstance.pay(developer,developer,reward,{ from: allowedAddress});
+        
+        initDevCampaignBalance = JSON.parse(await ExtendedFinanceInstance.getUserBalance(developer,{from: allowedAddress}));
         var internalBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance.call(developer,{ from: allowedAddress}));
-
+        
         await ExtendedFinanceInstance.withdrawRewards(developer,internalBalance,{ from: allowedAddress});
+        
+        var internalfinalBalance = JSON.parse(await ExtendedFinanceInstance.getRewardsBalance.call(developer,{ from: allowedAddress}));
+        var finalDevCampaignBalance = JSON.parse(await ExtendedFinanceInstance.getUserBalance(developer,{from: allowedAddress}));
+        
         expect(await TestUtils.getBalance(developer)).to.be.equal(initDevBalance + reward, 'Developer should receive his share');
+        expect(internalfinalBalance).to.be.equal(0,'All rewards should have been withdrawn');
+        expect(initDevCampaignBalance).to.be.not.equal(0,'Developer\'s campaign balance should not be 0');
+        expect(initDevCampaignBalance).to.be.equal(finalDevCampaignBalance,'Developer\'s campaign balance should not be changed');
     });
     
 });


### PR DESCRIPTION
## AppCoins Protocol smart contracts

Rewards balance and campaign balance are now in separate balance mappings.
This allows a whitelisted address to both create a campaign and withdraw rewards without withdrawing coins destined to address' campaings.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/AppStoreFoundation/asf-contracts/wiki/Contributing-to-AppCoins-Protocol-smart-contracts)
- [x] double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (at least 80% coverage)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues
