### PR TITLE
Fix/stop after error event

### DIFF
--- a/contracts/Advertisement.sol
+++ b/contracts/Advertisement.sol
@@ -78,7 +78,12 @@ contract Advertisement is BaseAdvertisement {
         external {
             
         CampaignLibrary.Campaign memory newCampaign = _generateCampaign(packageName, countries, vercodes, price, budget, startDate, endDate);
-        
+
+        if(newCampaign.owner == 0x0){ 
+            // campaign was not generated correctly (revert)
+            return;
+        }
+
         _getBidIdList().push(newCampaign.bidId);
 
         AdvertisementStorage(address(_getStorage())).setCampaign(

--- a/contracts/Base/BaseAdvertisement.sol
+++ b/contracts/Base/BaseAdvertisement.sol
@@ -142,30 +142,28 @@ contract BaseAdvertisement is StorageUser,Ownable {
         require(endDate >= startDate);
 
 
-
         //Transfers the budget to contract address
-        if(appc.allowance(msg.sender, address(this)) < budget){
+        if(appc.allowance(msg.sender, address(this)) >= budget){
+            appc.transferFrom(msg.sender, address(advertisementFinance), budget);
+
+            advertisementFinance.increaseBalance(msg.sender,budget);
+
+            uint newBidId = bytesToUint(lastBidId);
+            lastBidId = uintToBytes(++newBidId);
+            
+
+            CampaignLibrary.Campaign memory newCampaign;
+            newCampaign.price = price;
+            newCampaign.startDate = startDate;
+            newCampaign.endDate = endDate;
+            newCampaign.budget = budget;
+            newCampaign.owner = msg.sender;
+            newCampaign.valid = true;
+            newCampaign.bidId = lastBidId;
+        } else {
             emit Error("createCampaign","Not enough allowance");
-            return;
         }
-
-        appc.transferFrom(msg.sender, address(advertisementFinance), budget);
-
-        advertisementFinance.increaseBalance(msg.sender,budget);
-
-        uint newBidId = bytesToUint(lastBidId);
-        lastBidId = uintToBytes(++newBidId);
         
-
-        CampaignLibrary.Campaign memory newCampaign;
-        newCampaign.price = price;
-        newCampaign.startDate = startDate;
-        newCampaign.endDate = endDate;
-        newCampaign.budget = budget;
-        newCampaign.owner = msg.sender;
-        newCampaign.valid = true;
-        newCampaign.bidId = lastBidId;
-
         return newCampaign;
     }
 

--- a/contracts/ExtendedAdvertisement.sol
+++ b/contracts/ExtendedAdvertisement.sol
@@ -58,6 +58,11 @@ contract ExtendedAdvertisement is BaseAdvertisement, Whitelist {
         {
         
         CampaignLibrary.Campaign memory newCampaign = _generateCampaign(packageName, countries, vercodes, price, budget, startDate, endDate);
+
+        if(newCampaign.owner == 0x0){ 
+            // campaign was not generated correctly (revert)
+            return;
+        }
         
         _getBidIdList().push(newCampaign.bidId);
 

--- a/test/extendedAdvertisement.js
+++ b/test/extendedAdvertisement.js
@@ -50,7 +50,7 @@ contract('ExtendedAdvertisement', function(accounts) {
 
   		TestUtils.setAppCoinsInstance(appcInstance);
   		TestUtils.setContractInstance(addInstance);
-
+		//console.log("setup");
   		campaignPrice = 50000000000000000;
   		campaignBudget = 1000000000000000000;
 
@@ -105,7 +105,7 @@ contract('ExtendedAdvertisement', function(accounts) {
   		var countryList = []
   		var contractBalance = await TestUtils.getBalance(adFinanceInstance.address);
 
-		countryList.push(convertCountryCodeToIndex("PT"))
+    	countryList.push(convertCountryCodeToIndex("PT"))
 		countryList.push(convertCountryCodeToIndex("GB"))
 		countryList.push(convertCountryCodeToIndex("FR"))
 		countryList.push(convertCountryCodeToIndex("PA"))
@@ -126,7 +126,7 @@ contract('ExtendedAdvertisement', function(accounts) {
 				function(resolve, reject){
 		        eventsInfo.watch(function(error, log){ eventsInfo.stopWatching(); resolve(log); });
 		    });
-
+		
 	    assert.equal(eventStorageLog.event,"CampaignCreated", "Event must be a CampaignCreated event");
 	    assert.equal(eventStorageLog.args.bidId,bid,"BidId on campaign create event is not correct");
 	    assert.equal(eventStorageLog.args.price,campaignPrice,"Price on campaign create event is not correct");
@@ -141,14 +141,46 @@ contract('ExtendedAdvertisement', function(accounts) {
 	    assert.equal(eventInfoLog.args.countries[0],countryList[0],"Countries 1 on campaign info event are not correct");
 	    assert.equal(eventInfoLog.args.countries[1],countryList[1],"Countries 2 on campaign info event are not correct");
 	    assert.equal(eventInfoLog.args.countries[2],countryList[2],"Countries 3 on campaign info event are not correct");
-
-
+	
 		var budget = await addInstance.getBudgetOfCampaign.call(bid);
 
 		expect(JSON.parse(budget)).to.be.equal(campaignBudget,"Campaign budget is incorrect");
 		expect(await TestUtils.getBalance(adFinanceInstance.address)).to.be.equal(contractBalance+campaignBudget,"AppCoins are not being stored on AdvertisementFinance.");
 		expect(await TestUtils.getBalance(addInstance.address)).to.be.equal(0,"AppCoins should not be stored on ExtendedAdvertisement. contract.");
   	});
+	
+	it('should emit an error event if no approval was issued before creating a campaign', async function() {
+		var bid = web3.utils.toHex("0x0000000000000000000000000000000000000000000000000000000000000003");
+  		var countryList = []
+  		var contractBalance = await TestUtils.getBalance(adFinanceInstance.address);
+
+    	countryList.push(convertCountryCodeToIndex("PT"))
+		countryList.push(convertCountryCodeToIndex("GB"))
+		countryList.push(convertCountryCodeToIndex("FR"))
+		countryList.push(convertCountryCodeToIndex("PA"))
+
+		var eventsInfo = addInstance.allEvents();
+		var packageName1 = "com.instagram.android";
+
+		await addInstance.createCampaign(packageName1,countryList,[1,2],campaignPrice,campaignBudget,20,1922838059980, "appcoins.io");
+		
+		var eventNumber = -1;
+		var eventInfoLog = await new Promise(
+			function(resolve, reject){
+			eventsInfo.watch(function(error, log){ 
+				eventsInfo.stopWatching(); 
+				if(log.logIndex > eventNumber){
+					eventNumber = log.logIndex;
+				}
+				resolve(log); 
+			});
+		});
+
+		assert.equal(eventNumber,0,"Only 1 event should be emmited");
+		assert.equal(eventInfoLog.event,"Error","Event must be a Error event");
+		assert.equal(eventInfoLog.args.message,"Not enough allowance","Error message should be 'Not enough allowance'.")
+
+	})
 
 	it('should cancel a campaign as contract owner', async function () {
 		var bid = web3.utils.toHex("0x0000000000000000000000000000000000000000000000000000000000000002");


### PR DESCRIPTION
When creating a campaign with no allowance, the campaign would still be created and the events CamapaignCreated and CampaignUpdated would be thrown although no balance for that campaign would be avaliable.

This PR fixes this issue.

Before opening a pull request, please ensure:

- [ ] You have followed our [**contributing guidelines**](https://github.com/AppStoreFoundation/asf-contracts/wiki/Contributing-to-AppCoins-Protocol-smart-contracts)
- [x] double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (at least 80% coverage)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

