### PR TITLE
Extended Advertisement Changed to use SafeMath library

### DIFF
--- a/contracts/ExtendedAdvertisement.sol
+++ b/contracts/ExtendedAdvertisement.sol
@@ -5,7 +5,7 @@ import "./Base/Whitelist.sol";
 import "./Base/BaseAdvertisement.sol";
 import "./ExtendedAdvertisementStorage.sol";
 import "./ExtendedFinance.sol";
-
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 contract ExtendedAdvertisement is BaseAdvertisement, Whitelist {
 
@@ -118,7 +118,7 @@ contract ExtendedAdvertisement is BaseAdvertisement, Whitelist {
         uint price = _getStorage().getCampaignPriceById(_bidId);
         uint budget = _getStorage().getCampaignBudgetById(_bidId);
         address owner = _getStorage().getCampaignOwnerById(_bidId);
-        uint maxConversions = division(budget,price);
+        uint maxConversions = SafeMath.div(budget,price);
         uint effectiveConversions;
         uint totalPay;
         uint newBudget;
@@ -129,8 +129,9 @@ contract ExtendedAdvertisement is BaseAdvertisement, Whitelist {
             effectiveConversions = maxConversions;
         }
 
-        totalPay = price*effectiveConversions;
-        newBudget = budget - totalPay;
+        totalPay = SafeMath.mul(price,effectiveConversions);
+        
+        newBudget = SafeMath.sub(budget,totalPay);
 
         _getFinance().pay(owner, msg.sender, totalPay);
         _getStorage().setCampaignBudgetById(_bidId, newBudget);


### PR DESCRIPTION

## Description
Changed divistions, multiplications and subtractions on Extended Advertisement contract in order to ensure no integer underflow or overflow occurs when handling appCoins balance.
The integer under and overflow was fixed by using SafeMath library from [OpenZepplin repos](https://github.com/OpenZeppelin/openzeppelin-solidity).

## Motivation and Context
During the internal Security Audit to ASF Smart Contracts a possible integer overflow was detected which could lead to loss of tokens.

## How Has This Been Tested?
No further tests were created but all the current unit tests passed.

## Screenshots (if appropriate):

## Checklist:
- [x] You have followed our [**contributing guidelines**](https://github.com/AppStoreFoundation/asf-contracts/wiki/Contributing-to-AppCoins-Protocol-smart-contracts)
- [x] double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (at least 80% coverage)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues
