### PR TITLE
Feature/keep bid id list on advertisement update

### DIFF
--- a/contracts/Base/BaseAdvertisement.sol
+++ b/contracts/Base/BaseAdvertisement.sol
@@ -40,6 +40,30 @@ contract BaseAdvertisement is StorageUser,Ownable {
     }
 
 
+
+    /**
+    @notice Import existing bidIds
+    @dev
+        Method to import existing BidId list from an existing BaseAdvertisement contract
+        Be careful, this function does not chcek for duplicates.
+    @param _addrAdvert Address of the existing Advertisement contract from which the bidIds
+     will be imported  
+    */
+
+    function importBidIds(address _addrAdvert) public onlyOwner("importBidIds") {
+
+        bytes32[] memory _bidIdsToImport = BaseAdvertisement(_addrAdvert).getBidIdList();
+        bytes32 _lastStorageBidId = advertisementStorage.getLastBidId();
+
+        for (uint i = 0; i < _bidIdsToImport.length; i++) {
+            bidIdList.push(_bidIdsToImport[i]);
+        }
+        
+        if(lastBidId < _lastStorageBidId) {
+            lastBidId = _lastStorageBidId;
+        }
+    }
+
     /**
     @notice Upgrade finance contract used by this contract
     @dev


### PR DESCRIPTION

## Description
Add function `importbidIds` to Base Advertisement contract.

## Motivation and Context
When trying to upgrade Extended Advertisement it was found that the campaign id list on the new Extended Advertisement contract does not include existing campaign Ids.
Although a trusted party operating the Extended Advertisement contract can keep an off-chain tracking for active campaigns, it would be better to keep an updated campaign Id list on the new contract.

## How Has This Been Tested?
A new test was added to ensure the new `importbidIds` function works as intended.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] You have followed our [**contributing guidelines**](https://github.com/AppStoreFoundation/asf-contracts/wiki/Contributing-to-AppCoins-Protocol-smart-contracts)
- [x] double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (at least 80% coverage)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues
