### PR TITLE
Updated deprecated dependancies of package.json and added new contract

### DIFF
--- a/contracts/AppCoinsTracker.sol
+++ b/contracts/AppCoinsTracker.sol
@@ -1,0 +1,134 @@
+/**
+ *Submitted for verification at Etherscan.io on 2020-08-28
+*/
+
+pragma solidity 0.6.7;
+pragma experimental ABIEncoderV2;
+
+contract AppCoinsTracker {
+
+    ///////// STRUCTS /////////
+    struct CampaignLaunchedInformation {
+        bytes32 bidId;
+        string packageName;
+        string endPoint;
+        uint[3] countries;
+        uint price;
+        uint budget;
+        uint startDate;
+        uint endDate;
+    }
+
+    struct BulkPoaInformation {
+        bytes32 bidId;
+        bytes rootHash;
+        uint256 newHashes;
+    }
+
+    struct OffChainBuyInformation {
+        address wallet;
+        bytes32 rootHash;
+    }
+    ///////// END: STRUCTS /////////
+
+    ///////// EVENTS /////////
+    event CampaignLaunched(
+        address owner,
+        bytes32 bidId,
+        string packageName,
+        uint[3] countries,
+        uint price,
+        uint budget,
+        uint startDate,
+        uint endDate,
+        string endPoint
+    );
+
+    event CampaignCancelled(
+        address owner,
+        bytes32 bidId
+    );
+
+    event BulkPoARegistered(
+        address owner,
+        bytes32 bidId,
+        bytes rootHash,
+        uint256 newHashes
+    );
+
+    event OffChainBuy(
+        address _wallet, 
+        bytes32 _rootHash
+    );
+    ///////// END: EVENTS /////////
+
+    /**
+    @notice Emits events informing the launch of campaigns.
+    @dev For each CampaignLaunchedInformation passed as argument is emited in
+         a CampaignedLaunched event.
+    @param _campaigns_launched_information List of CampaignLaunchedInformation
+           containing the information of campaigns that have been lauched.
+    */
+    function createCampaigns (CampaignLaunchedInformation[] memory 
+                _campaigns_launched_information)public {
+        for(uint i = 0; i < _campaigns_launched_information.length; i++){
+            emit CampaignLaunched(
+                msg.sender,
+                _campaigns_launched_information[i].bidId,
+                _campaigns_launched_information[i].packageName,
+                _campaigns_launched_information[i].countries,
+                _campaigns_launched_information[i].price,
+                _campaigns_launched_information[i].budget,
+                _campaigns_launched_information[i].startDate,
+                _campaigns_launched_information[i].endDate,
+                _campaigns_launched_information[i].endPoint
+            );
+        }
+    }
+
+    /**
+    @notice Emits events informing the cancelation of campaigns.
+    @dev For each bidId passed as argument is emited in a CampaignedCancel event.
+    @param _bidIdList List of bidId of campaigns that have been cancelled.
+    */
+    function cancelCampaigns (bytes32[] memory _bidIdList) public {
+        for(uint i = 0; i < _bidIdList.length; i++) {
+            emit CampaignCancelled(msg.sender, _bidIdList[i]);
+        }
+    }
+
+    /**
+    @notice Emits events registering the root hash of the proof-of-attentions
+            transactions of a multiple campaign.
+    @dev For each BulkPoaInformation passed as argument is emited in a 
+         BulkPoARegistered event.
+    @param _bulks_poa_information List of BulkPoaInformation of campaigns that 
+                                  have PoA that haven't been registered.
+    */
+    function bulkRegisterPoaOfCampaigns (BulkPoaInformation[] memory 
+                _bulks_poa_information) public {
+        for(uint i = 0; i < _bulks_poa_information.length; i++) {
+            emit BulkPoARegistered(
+                msg.sender,
+                _bulks_poa_information[i].bidId,
+                _bulks_poa_information[i].rootHash,
+                _bulks_poa_information[i].newHashes
+            );
+        }
+    }
+
+    /**
+    @notice Emits events informing offchain transactions for in-app-billing
+    @dev For each OffChainBuyInformation passed as argument is emited in a OffChainBuyInformation 
+         event.
+    @param _off_chain_buys List of OffChainBuyInformation - wallets and rootHashes - for 
+                           which a OffChainBuyInformation event will be issued.
+    */
+    function informOffChainBuys(OffChainBuyInformation[] memory 
+                _off_chain_buys) public {
+        for(uint i = 0; i < _off_chain_buys.length; i++){
+            emit OffChainBuy(_off_chain_buys[i].wallet,
+                             _off_chain_buys[i].rootHash);
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,19 +7,18 @@
     "test": "test"
   },
   "dependencies": {
-    "big-number": "^0.4.0",
+    "big-number": "^2.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "dotenv": "^5.0.1",
-    "ganache-cli": "6.1.8",
-    "openzeppelin-solidity": "1.12.0",
+    "dotenv": "^8.2.0",
+    "ganache-cli": "^6.10.1",
+    "openzeppelin-solidity": "^1.12.0",
     "pre-commit": "^1.2.2",
-    "solhint": "^1.2.1",
-    "solium": "1.1.7",
-    "truffle": "4.1.14",
-    "truffle-hdwallet-provider": "0.0.3",
-    "typedarray-to-buffer": "^3.1.5",
-    "web3": "1.0.0-beta.36"
+    "solhint": "^3.2.0",
+    "solium": "^1.2.5",
+    "truffle": "^5.1.43",
+    "truffle-hdwallet-provider": "^1.0.17",
+    "web3": "^1.2.11"
   },
   "repository": {
     "type": "git",
@@ -27,9 +26,9 @@
   },
   "homepage": "https://AppStoreFoundation.github.io",
   "devDependencies": {
-    "cz-conventional-changelog": "^2.1.0",
-    "semantic-release": "^15.5.1",
-    "solidity-coverage": "0.5.11"
+    "cz-conventional-changelog": "^3.3.0",
+    "semantic-release": "^17.1.1",
+    "solidity-coverage": "^0.7.10"
   },
   "scripts": {
     "test": "truffle test",


### PR DESCRIPTION
Updated package.json dependencies and added new contract AppCoinsTracker

## Description
Went through the dependencies in package.json and updated the deprecated ones and checked if everything was still working as is should. 

## Motivation and Context
Grantees that the contracts aren't using deprecated dependancies.

## How Has This Been Tested?
Tested through truffle test and also other python tests. The python tests where made only for the contracts that are currently in use (AppCoins, AppCoinsIAB, AppCoinsTracker, AddressProxy).

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] You have followed our [**contributing guidelines**](https://github.com/AppStoreFoundation/asf-contracts/wiki/Contributing-to-AppCoins-Protocol-smart-contracts)
- [x] double-check your branch is based on `dev` and targets `dev` 
- [ ] Pull request has tests (at least 80% coverage)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues
